### PR TITLE
ci: check example branches and add renovate

### DIFF
--- a/.github/workflows/example-check.yml
+++ b/.github/workflows/example-check.yml
@@ -1,0 +1,86 @@
+name: Check example branches
+
+on:
+  push:
+    branches: [ 'example/**' ]
+  schedule:
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 22.23.2
+  ENABLE_CACHE: yes
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ github.event_name == 'schedule' && fromJSON('["prod", "example/minimal", "example/custom-server", "example/localization"]') || fromJSON(format('["{0}"]', github.ref_name)) }}
+    concurrency:
+      group: ${{ matrix.branch }}-check-example
+      cancel-in-progress: true
+
+    steps:
+      # Establish origin and checkout credentials before probing the target branch.
+      - uses: actions/checkout@v4
+
+      - name: Check branch exists
+        id: branch
+        env:
+          BRANCH: ${{ matrix.branch }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$BRANCH"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [ "$status" -ne 2 ]; then
+              echo "Unable to check branch $BRANCH (git exit $status)." >&2
+              exit "$status"
+            fi
+            echo "Branch $BRANCH does not exist yet; skipping."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.branch.outputs.exists == 'true'
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: actions/setup-node@v4
+        if: steps.branch.outputs.exists == 'true'
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: ${{ env.ENABLE_CACHE == 'yes' && 'npm' || '' }}
+
+      - name: Install dependencies
+        if: steps.branch.outputs.exists == 'true'
+        run: npm ci --ignore-scripts
+
+      - name: Commit lint latest title
+        if: steps.branch.outputs.exists == 'true'
+        run: git log -1 --format=%s | npx --no-install commitlint -g commitlint.config.js
+
+      - name: Check eslint
+        if: steps.branch.outputs.exists == 'true'
+        run: npm run lint:check
+
+      - name: Typescript check
+        if: steps.branch.outputs.exists == 'true'
+        run: npm run ts:check
+
+      - name: Stylelint check
+        if: steps.branch.outputs.exists == 'true'
+        run: npm run style:check
+
+      - name: Build check
+        if: steps.branch.outputs.exists == 'true'
+        run: npm run build -- --throw-warnings
+
+      - name: Smoke check
+        if: steps.branch.outputs.exists == 'true'
+        run: npm run smoke

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,8 +2,8 @@ name: Check PR
 
 on:
   pull_request:
-    branches: [ prod ]
-    types: [ synchronize ]
+    branches: [ prod, 'example/**' ]
+    types: [ opened, synchronize, reopened ]
 
 env:
   NODE_VERSION: 22.23.2
@@ -41,3 +41,6 @@ jobs:
 
       - name: Build check
         run: npm run build -- --throw-warnings
+
+      - name: Smoke check
+        run: npm run smoke

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,20 +1,17 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # validate commit
 npx --no-install commitlint -g commitlint.config.js --edit "$1"
 
-LC_ALL=C
+export LC_ALL=C
 
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 
-valid_branch_regex="^(feature|bugfix|improvement|hotfix)\/[a-z0-9-]+$"
+valid_branch_regex="^(feature|bugfix|improvement|hotfix|example)/[a-z0-9-]+$"
 
 message="There is something wrong with your branch name. Branch names in this project must adhere to this contract: $valid_branch_regex. Your commit will be rejected. You should rename your branch to a valid name and try again."
 
 # validate branch name
-# shellcheck disable=SC2039
-if [ ! $local_branch =~ $valid_branch_regex ] && [ ! "$local_branch" == "staging" ] && [ ! "$local_branch" == "prod" ]; then
+if [ "$local_branch" != "staging" ] && [ "$local_branch" != "prod" ] &&
+  ! printf '%s\n' "$local_branch" | grep -Eq "$valid_branch_regex"; then
   echo "$message"
   exit 1
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
 # Vite template
 
+## Branches
+
+| Branch | What it shows | When to start from it | Link |
+| --- | --- | --- | --- |
+| `prod` | Streaming SSR, MobX, consistent Suspense, meta tags and route management | Use the full reference app | [Browse](https://github.com/Lomray-Software/vite-template/tree/prod) |
+| `example/minimal` (planned) | Minimal SSR with loaders and route-level CSS | Start with a small SSR app once available | Planned |
+| `example/custom-server` (planned) | A custom Fastify server | Own the production server once available | Planned |
+| `example/localization` (planned) | Localization with server and client language state | Add localization once available | Planned |
+
 ## Demo links
- - Streaming supported
-   - [SSR Docker (Streaming supported)](https://vite-template.lomray.com/)
- - Streaming **NOT** supported
-   - [SSR Amplify (Streaming not supported)](https://prod.d947n8vxd7uac.amplifyapp.com/)  
-   - [SSR Vercel (Streaming supported)](https://vite-template-three.vercel.app/)  
-   - [SPA Amplify](https://prod.d2fyemmi74bwx3.amplifyapp.com/)
+
+### Streaming supported
+
+- [SSR Docker (Streaming supported)](https://vite-template.lomray.com/)
+- [SSR Vercel (Streaming supported)](https://vite-template-three.vercel.app/)
+
+### Streaming not supported
+
+- [SSR Amplify (Streaming not supported)](https://prod.d947n8vxd7uac.amplifyapp.com/)
+
+### SPA
+
+- [SPA Amplify](https://prod.d2fyemmi74bwx3.amplifyapp.com/)
 
 ## Explore
  - [prod](https://github.com/Lomray-Software/vite-template/tree/prod) current branch with Mobx + Store Manager, Head Manager (meta), Route Manager
@@ -111,7 +127,7 @@ frontend:
         - npm ci
     build:
       commands:
-        - npm run build -- --only-client
+        - npm run build -- --focus-only client
   artifacts:
     baseDirectory: build/client
     files:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start:ssr": "ssr-boost start",
     "start:spa": "ssr-boost start --focus-only client",
     "preview": "ssr-boost preview",
+    "smoke": "node scripts/smoke.mjs",
     "lint:check": "eslint \"src/**/*.{ts,tsx,*.ts,*tsx}\"",
     "lint:format": "eslint --fix \"src/**/*.{ts,tsx,*.ts,*tsx}\"",
     "style:check": "stylelint \"src/**/*.{css,scss}\"",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "baseBranches": ["prod"],
+  "rangeStrategy": "bump",
+  "automerge": false,
+  "labels": ["dependencies"],
+  "separateMajorMinor": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["!major"],
+      "groupName": "non-major dependencies",
+      "schedule": ["* 0-5 * * 1"]
+    },
+    {
+      "matchPackageNames": ["@lomray/*"],
+      "matchUpdateTypes": ["!major"],
+      "groupName": "Lomray dependencies",
+      "schedule": ["* 0-5 * * 1"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    }
+  ]
+}

--- a/scripts/smoke.config.json
+++ b/scripts/smoke.config.json
@@ -1,0 +1,14 @@
+{
+  "routes": [
+    { "path": "/", "status": 200, "contains": ["window.__staticRouterHydrationData"] },
+    { "path": "/not-lazy", "status": 200, "contains": ["Styled text"] },
+    { "path": "/redirect-demo", "status": 301 },
+    { "path": "/missing", "status": 404 },
+    { "path": "/details", "status": 200 },
+    { "path": "/nested-suspense", "status": 200 },
+    { "path": "/error-boundary", "status": 200 },
+    { "path": "/only-client-page", "status": 200 }
+  ],
+  "streamPath": "/details",
+  "crawlerCookie": "isCrawler=1"
+}

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import http from 'node:http';
+import net from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { createGunzip } from 'node:zlib';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const cli = fileURLToPath(
+  new URL('../node_modules/@lomray/vite-ssr-boost/cli.js', import.meta.url),
+);
+const children = new Set();
+let interrupted = false;
+
+// Keep the HTTP and process helpers self-contained, following scripts/test-template.mjs
+// in vite-ssr-boost. Count decoded HTML chunks so gzip headers cannot pass the stream check.
+const getPort = async () => {
+  const server = net.createServer();
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  const closed = once(server, 'close');
+
+  server.close();
+  await closed;
+
+  return port;
+};
+
+const startProcess = (command, args) => {
+  assert.ok(!interrupted, 'Smoke check interrupted.');
+  const child = spawn(command, args, { cwd: root, stdio: 'inherit', detached: true });
+  const processState = { child, result: null, done: null, stopping: null };
+
+  processState.done = new Promise((resolve) => {
+    const finish = (result) => {
+      processState.result = result;
+      resolve(result);
+    };
+
+    child.once('error', (error) => finish({ error }));
+    child.once('exit', (code, signal) => finish({ code, signal }));
+  });
+  children.add(processState);
+
+  return processState;
+};
+
+const stop = (state) => {
+  state.stopping ??= (async () => {
+    const signalGroup = (signal) => {
+      if (!state.child.pid) {
+        return;
+      }
+
+      try {
+        process.kill(-state.child.pid, signal);
+      } catch (error) {
+        if (error.code !== 'ESRCH') {
+          throw error;
+        }
+      }
+    };
+
+    signalGroup('SIGTERM');
+    const timeout = setTimeout(() => signalGroup('SIGKILL'), 3_000);
+
+    try {
+      await state.done;
+    } finally {
+      clearTimeout(timeout);
+      children.delete(state);
+    }
+  })();
+
+  return state.stopping;
+};
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, async () => {
+    interrupted = true;
+    console.error(`[smoke] Interrupted by ${signal}.`);
+    await Promise.all([...children].map(stop));
+    process.exit(1);
+  });
+}
+
+const build = async (args = []) => {
+  console.info(`[smoke] env -u NO_COLOR npx ssr-boost build ${args.join(' ')}`.trim());
+  const state = startProcess('env', ['-u', 'NO_COLOR', 'npx', 'ssr-boost', 'build', ...args]);
+  const { code, signal, error } = await state.done;
+
+  if (error) {
+    throw error;
+  }
+
+  assert.equal(code, 0, `ssr-boost build failed (${signal ?? code}).`);
+  children.delete(state);
+};
+
+const inspect = (origin, pathname, { method = 'GET', headers = {}, timeout = 30_000 } = {}) =>
+  new Promise((resolve, reject) => {
+    const request = http.request(
+      new URL(pathname, origin),
+      { method, headers, signal: AbortSignal.timeout(timeout) },
+      (response) => {
+        const chunks = [];
+        const decoded =
+          response.headers['content-encoding'] === 'gzip'
+            ? response.pipe(createGunzip())
+            : response;
+
+        decoded.on('data', (chunk) => chunks.push(chunk));
+        decoded.on('end', () => {
+          resolve({
+            status: response.statusCode,
+            html: Buffer.concat(chunks).toString('utf8'),
+            chunks: chunks.length,
+          });
+        });
+        response.on('error', reject);
+        decoded.on('error', reject);
+      },
+    );
+
+    request.on('error', (error) => reject(new Error(`${method} ${pathname}: ${error.message}`)));
+    request.end();
+  });
+
+const waitUntilReady = async (origin, state) => {
+  const deadline = Date.now() + 30_000;
+
+  while (Date.now() < deadline) {
+    assert.ok(!interrupted, 'Smoke check interrupted.');
+    assert.ok(
+      !state.result,
+      `Server exited before readiness (${state.result?.error?.message ?? state.result?.signal ?? state.result?.code}).`,
+    );
+
+    try {
+      await inspect(origin, '/', { timeout: 1_000 });
+
+      return;
+    } catch {
+      await delay(100);
+    }
+  }
+
+  throw new Error(`Server did not become ready within 30 seconds: ${origin}`);
+};
+
+const withServer = async (mode, args, verify) => {
+  const port = await getPort();
+  const origin = `http://127.0.0.1:${port}`;
+  const state = startProcess(process.execPath, [cli, 'start', ...args, '--port', String(port)]);
+
+  console.info(`[smoke] Starting ${mode} server on port ${port} (PID ${state.child.pid}).`);
+
+  try {
+    await waitUntilReady(origin, state);
+    await verify(origin);
+  } finally {
+    await stop(state);
+    console.info(`[smoke] Stopped ${mode} server (PID ${state.child.pid}).`);
+  }
+};
+
+try {
+  const config = JSON.parse(
+    await readFile(new URL('./smoke.config.json', import.meta.url), 'utf8'),
+  );
+  const { routes, streamPath, crawlerCookie } = config;
+
+  assert.ok(Array.isArray(routes) && routes.length > 0, 'Configure at least one smoke route.');
+  assert.ok(typeof streamPath === 'string' && streamPath.startsWith('/'), 'Configure streamPath.');
+  assert.ok(
+    typeof crawlerCookie === 'string' && crawlerCookie.length > 0,
+    'Configure crawlerCookie.',
+  );
+
+  await build();
+  await withServer('SSR', [], async (origin) => {
+    for (const { path, status, contains = [], headers = {} } of routes) {
+      const response = await inspect(origin, path, { headers });
+
+      assert.equal(response.status, status, `SSR GET ${path}: expected status ${status}.`);
+      for (const marker of contains) {
+        assert.ok(
+          response.html.includes(marker),
+          `SSR GET ${path}: missing ${JSON.stringify(marker)}.`,
+        );
+      }
+
+      console.info(`[smoke] SSR GET ${path}: ${status}; ${contains.length} content checks passed.`);
+    }
+
+    const first = routes[0];
+    const head = await inspect(origin, first.path, { method: 'HEAD', headers: first.headers });
+
+    assert.equal(head.status, first.status, `SSR HEAD ${first.path}: unexpected status.`);
+    assert.equal(head.html, '', `SSR HEAD ${first.path}: expected an empty body.`);
+    console.info(`[smoke] SSR HEAD ${first.path}: ${head.status}; empty body.`);
+
+    const streamed = await inspect(origin, streamPath);
+
+    assert.equal(streamed.status, 200, `SSR stream ${streamPath}: expected status 200.`);
+    assert.ok(
+      streamed.chunks > 1,
+      `SSR stream ${streamPath}: expected more than one HTML chunk, got ${streamed.chunks}.`,
+    );
+    console.info(`[smoke] SSR stream ${streamPath}: ${streamed.chunks} HTML chunks.`);
+
+    const crawler = await inspect(origin, streamPath, { headers: { Cookie: crawlerCookie } });
+
+    assert.equal(crawler.status, 200, `SSR crawler ${streamPath}: expected status 200.`);
+    assert.ok(
+      !crawler.html.includes('<!--$?-->'),
+      `SSR crawler ${streamPath}: pending Suspense boundary.`,
+    );
+    console.info(`[smoke] SSR crawler ${streamPath}: 200; no pending Suspense boundaries.`);
+  });
+
+  await build(['--focus-only', 'client']);
+  await withServer('SPA', ['--focus-only', 'client'], async (origin) => {
+    for (const path of ['/', streamPath]) {
+      const response = await inspect(origin, path);
+
+      assert.equal(response.status, 200, `SPA GET ${path}: expected status 200.`);
+      assert.ok(
+        !response.html.includes('window.__staticRouterHydrationData'),
+        `SPA GET ${path}: unexpected hydration data.`,
+      );
+      console.info(`[smoke] SPA GET ${path}: 200; no hydration data.`);
+    }
+  });
+
+  console.info('[smoke] All checks passed.');
+} catch (error) {
+  console.error(`[smoke] FAILED: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  await Promise.all([...children].map(stop));
+}


### PR DESCRIPTION
## Goal

Complete T3, steps 0–6, of the vite-ssr-boost v8 follow-up plan. Add shared smoke checks and CI coverage for example branches, configure dependency updates, repair branch validation, and document the branch layout. Target: `prod`. Working branch: `feature/example-branch-ci`, based on `713958ec57cdae8f257f00a7b1827c21da8e3211`.

## Changes

- `.husky/commit-msg` and `.husky/pre-commit`: remove deprecated Husky initialization; validate branch names with portable shell syntax, allow `example/*`, and retain the `prod` and `staging` exemptions.
- `scripts/smoke.mjs`, `scripts/smoke.config.json`, and `package.json`: add a Node built-ins-only SSR/SPA smoke runner covering all eight configured routes, content markers, HEAD, streaming, crawler buffering, and SPA hydration-data absence; track and stop child processes on completion, failure, or interruption.
- `.github/workflows/pr-check.yml`: check opened, synchronized, and reopened PRs targeting `prod` or `example/**`; run smoke after the build.
- `.github/workflows/example-check.yml`: check pushed example branches and run the four-branch matrix every Monday at 06:17 UTC; skip missing branches before their checkout and checks; lint the latest commit title because push and schedule events have no PR title.
- `renovate.json`: target `prod`, use recommended defaults and bumped ranges, group non-major updates weekly with a separate Lomray group, keep major updates separate, disable automerge, and label updates `dependencies`.
- `README.md`: add the Branches table with three planned examples, place each retained demo link under the matching heading, and correct the Amplify SPA command to `--focus-only client`.

## Verification

- `npm run smoke` → exit 0 on `feature/example-branch-ci`. Full output follows, with terminal color codes removed. The error-boundary route intentionally throws the error defined in `src/pages/error-boundary/stores/main/index.ts`; its configured HTTP status check passed.

```text
> @lomray/vite-template@1.0.0 smoke
> node scripts/smoke.mjs

[smoke] env -u NO_COLOR npx ssr-boost build
vite cache cleared.
vite v8.2.2 building client environment for production...
transforming...
✓ 197 modules transformed.
rendering chunks...
computing gzip size...
build/client/index.html                                 0.65 kB │ gzip:  0.38 kB
build/client/assets/react-CHdo91hT.svg                  4.12 kB │ gzip:  2.06 kB
build/client/.vite/manifest.json                        4.31 kB │ gzip:  0.76 kB
build/client/assets/user-DzTcHV1P.css                   0.14 kB │ gzip:  0.13 kB
build/client/assets/home-DUTy1HTl.css                   0.32 kB │ gzip:  0.23 kB
build/client/assets/index-YQCkxvAz.css                  1.05 kB │ gzip:  0.47 kB
build/client/assets/index-CpNY0hfr.css                  1.53 kB │ gzip:  0.73 kB
build/client/assets/code-splitting-zuI-oce9.js          0.13 kB │ gzip:  0.14 kB
build/client/assets/only-client-page-CqLttWOy.js        0.35 kB │ gzip:  0.24 kB
build/client/assets/error-boundary-route-CRQli-Au.js    0.47 kB │ gzip:  0.31 kB
build/client/assets/error-boundary-C1uKVx_D.js          0.59 kB │ gzip:  0.40 kB
build/client/assets/rolldown-runtime-hePW80VL.js        0.71 kB │ gzip:  0.42 kB
build/client/assets/redirect-GM_XlYbT.js                0.72 kB │ gzip:  0.49 kB
build/client/assets/user-B5gz_sDk.js                    1.43 kB │ gzip:  0.75 kB
build/client/assets/suspense-query-DX0zl4NI.js          1.50 kB │ gzip:  0.69 kB
build/client/assets/nested-suspense-BPZGQwNu.js         1.71 kB │ gzip:  0.83 kB
build/client/assets/index-mw51s1KI.js                   4.07 kB │ gzip:  1.82 kB
build/client/assets/home-CgZ9PCK3.js                    5.01 kB │ gzip:  1.98 kB
build/client/assets/axios-Cwt1K6go.js                  49.95 kB │ gzip: 18.75 kB
build/client/assets/chunk-BV7QT456-C9HmpVyk.js        100.69 kB │ gzip: 33.33 kB
build/client/assets/index-leKG7V9b.js                 300.81 kB │ gzip: 93.66 kB

✓ built in 628ms
vite v8.2.2 building ssr environment for production...
transforming...
✓ 43 modules transformed.
rendering chunks...
computing gzip size...
build/server/assets/code-splitting-DQ2rcWU0.js        0.35 kB │ gzip: 0.25 kB
build/server/assets/only-client-page-yOmcEFBJ.js      0.64 kB │ gzip: 0.35 kB
build/server/assets/redirect-C-jfmUFo.js              0.74 kB │ gzip: 0.43 kB
build/server/assets/error-boundary-route-CrDm5iDj.js  1.09 kB │ gzip: 0.51 kB
build/server/assets/error-boundary-Dji8Zk6I.js        1.43 kB │ gzip: 0.65 kB
build/server/assets/user-CqWJFawj.js                  2.74 kB │ gzip: 1.08 kB
build/server/assets/nested-suspense-DjY7vbGA.js       3.58 kB │ gzip: 1.27 kB
build/server/assets/home-BWZVPehe.js                  4.88 kB │ gzip: 1.41 kB
build/server/assets/index-BYEH0oo6.js                 5.11 kB │ gzip: 1.73 kB
build/server/server.js                                9.61 kB │ gzip: 3.06 kB

✓ built in 145ms
Building routes manifest file

  SSR-BOOST  client,server built in 1.49 s 

[smoke] Starting SSR server on port 54600 (PID 9279).

  SSR-BOOST v8.0.0-beta.2  ready in 75 ms

  ➜  Mode:    production
  ➜  Type:    SSR
  ➜  Local:   http://127.0.0.1:54600/


[smoke] SSR GET /: 200; 1 content checks passed.
[smoke] SSR GET /not-lazy: 200; 1 content checks passed.
[smoke] SSR GET /redirect-demo: 301; 0 content checks passed.
[smoke] SSR GET /missing: 404; 0 content checks passed.
[smoke] SSR GET /details: 200; 0 content checks passed.
[smoke] SSR GET /nested-suspense: 200; 0 content checks passed.
Emulate request...
Stream error. Code: unknown
Error: Ooops. I'm caught error? :)
    at s.throwError (file:///Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/@lomray/react-mobx-manager/suspense-query.js:1:557)
    at s.isComplete (file:///Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/@lomray/react-mobx-manager/suspense-query.js:1:690)
    at s.query (file:///Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/@lomray/react-mobx-manager/suspense-query.js:1:799)
    at ErrorBoundaryPage (file:///Users/mikhail/work/lomray/agent/vite-template-t3/build/server/assets/error-boundary-Dji8Zk6I.js:44:11)
    at Object.react_stack_bottom_frame (/Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/react-dom/cjs/react-dom-server.node.development.js:9176:18)
    at renderWithHooks (/Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/react-dom/cjs/react-dom-server.node.development.js:4797:19)
    at renderElement (/Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/react-dom/cjs/react-dom-server.node.development.js:5232:23)
    at retryNode (/Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/react-dom/cjs/react-dom-server.node.development.js:5991:31)
    at performWork (/Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/react-dom/cjs/react-dom-server.node.development.js:6835:17)
    at Immediate._onImmediate (/Users/mikhail/work/lomray/agent/vite-template-t3/node_modules/react-dom/cjs/react-dom-server.node.development.js:4476:22)
[smoke] SSR GET /error-boundary: 200; 0 content checks passed.
[smoke] SSR GET /only-client-page: 200; 0 content checks passed.
[smoke] SSR HEAD /: 200; empty body.
[smoke] SSR stream /details: 7 HTML chunks.
[smoke] SSR crawler /details: 200; no pending Suspense boundaries.
[smoke] Stopped SSR server (PID 9279).
[smoke] env -u NO_COLOR npx ssr-boost build --focus-only client
vite cache cleared.
vite v8.2.2 building client environment for production...
transforming...
✓ 197 modules transformed.
rendering chunks...
computing gzip size...
build/client/index.html                                 0.65 kB │ gzip:  0.38 kB
build/client/assets/react-CHdo91hT.svg                  4.12 kB │ gzip:  2.06 kB
build/client/assets/user-DzTcHV1P.css                   0.14 kB │ gzip:  0.13 kB
build/client/assets/home-DUTy1HTl.css                   0.32 kB │ gzip:  0.23 kB
build/client/assets/index-YQCkxvAz.css                  1.05 kB │ gzip:  0.47 kB
build/client/assets/index-CpNY0hfr.css                  1.53 kB │ gzip:  0.73 kB
build/client/assets/code-splitting-B4uUwHEf.js          0.13 kB │ gzip:  0.14 kB
build/client/assets/only-client-page-D8zXEuGa.js        0.35 kB │ gzip:  0.25 kB
build/client/assets/error-boundary-route-CwuW6KZ9.js    0.47 kB │ gzip:  0.32 kB
build/client/assets/error-boundary-Cd71rwx1.js          0.59 kB │ gzip:  0.41 kB
build/client/assets/rolldown-runtime-hePW80VL.js        0.71 kB │ gzip:  0.42 kB
build/client/assets/redirect-b8ld9Gpk.js                0.72 kB │ gzip:  0.49 kB
build/client/assets/user-fcJyPUIS.js                    1.43 kB │ gzip:  0.75 kB
build/client/assets/suspense-query-BN0X2YjD.js          1.50 kB │ gzip:  0.69 kB
build/client/assets/nested-suspense-D6Hz3Naj.js         1.71 kB │ gzip:  0.83 kB
build/client/assets/index-Ct0aBwNb.js                   4.07 kB │ gzip:  1.82 kB
build/client/assets/home-Dya9kTpx.js                    5.01 kB │ gzip:  1.98 kB
build/client/assets/axios-Cwt1K6go.js                  49.95 kB │ gzip: 18.75 kB
build/client/assets/chunk-BV7QT456-C9HmpVyk.js        100.69 kB │ gzip: 33.33 kB
build/client/assets/index-BRuGTPeq.js                 300.74 kB │ gzip: 93.63 kB

✓ built in 228ms

  SSR-BOOST  client built in 523 ms 

[smoke] Starting SPA server on port 54641 (PID 9538).

  SSR-BOOST v8.0.0-beta.2  ready in 5 ms

  ➜  Mode:    production
  ➜  Type:    SPA
  ➜  Local:   http://127.0.0.1:54641/


[smoke] SPA GET /: 200; no hydration data.
[smoke] SPA GET /details: 200; no hydration data.
[smoke] Stopped SPA server (PID 9538).
[smoke] All checks passed.
```

- Husky proof → the invalid branch rejected an empty commit with exit 1; the valid branch accepted it with exit 0. Both throwaway branches were deleted with `git branch -D`, and the working branch returned to the original base before the real commit. Full output follows.

```text
$ git switch -c chore/should-fail feature/example-branch-ci
Switched to a new branch 'chore/should-fail'
M	.husky/commit-msg
M	.husky/pre-commit
Exit: 0
$ git commit --allow-empty -m "ci: verify branch hook"
→ lint-staged could not find any staged files.
There is something wrong with your branch name. Branch names in this project must adhere to this contract: ^(feature|bugfix|improvement|hotfix|example)/[a-z0-9-]+$. Your commit will be rejected. You should rename your branch to a valid name and try again.
husky - commit-msg script failed (code 1)
Exit: 1
$ git switch -c feature/should-pass feature/example-branch-ci
Switched to a new branch 'feature/should-pass'
M	.husky/commit-msg
M	.husky/pre-commit
Exit: 0
$ git commit --allow-empty -m "ci: verify branch hook"
→ lint-staged could not find any staged files.
[feature/should-pass 242d9e0] ci: verify branch hook
Exit: 0
$ git switch feature/example-branch-ci
Switched to branch 'feature/example-branch-ci'
M	.husky/commit-msg
M	.husky/pre-commit
Your branch is up to date with 'origin/prod'.
Exit: 0
$ git branch -D chore/should-fail
Deleted branch chore/should-fail (was 713958e).
Exit: 0
$ git branch -D feature/should-pass
Deleted branch feature/should-pass (was 242d9e0).
Exit: 0
$ git status --short --branch
## feature/example-branch-ci...origin/prod
 M .husky/commit-msg
 M .husky/pre-commit
Exit: 0
```

- `npx --yes --package renovate -- renovate-config-validator` → exit 0. Full output follows, including installation deprecations and the migration warning for the explicitly required `baseBranches` field.

```text
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated git-raw-commits@2.0.11: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
npm warn deprecated boolean@3.2.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
npm warn deprecated rimraf@2.4.5: Rimraf versions prior to v4 are no longer supported
npm warn deprecated prebuild-install@7.1.3: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
npm warn deprecated tar@6.2.1: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
npm warn deprecated uuid@9.0.1: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
npm warn deprecated glob@6.0.4: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
npm warn deprecated @aws-sdk/client-ec2@3.958.0: upgrade to @aws-sdk/client-ec2 v3.989.0+ for a serialization fix. Info at https://github.com/aws/aws-sdk-js-v3/pull/7734.
npm warn deprecated renovate@42.99.0: Renovate versions older than the latest major version are unsupported
npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 INFO: Validating renovate.json
 WARN: Config migration necessary
       "oldConfig": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["config:recommended"],
         "baseBranches": ["prod"],
         "rangeStrategy": "bump",
         "automerge": false,
         "labels": ["dependencies"],
         "separateMajorMinor": true,
         "packageRules": [
           {
             "matchUpdateTypes": ["!major"],
             "groupName": "non-major dependencies",
             "schedule": ["* 0-5 * * 1"]
           },
           {
             "matchPackageNames": ["@lomray/*"],
             "matchUpdateTypes": ["!major"],
             "groupName": "Lomray dependencies",
             "schedule": ["* 0-5 * * 1"]
           },
           {"matchUpdateTypes": ["major"], "groupName": null}
         ]
       },
       "newConfig": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["config:recommended"],
         "baseBranchPatterns": ["prod"],
         "rangeStrategy": "bump",
         "automerge": false,
         "labels": ["dependencies"],
         "separateMajorMinor": true,
         "packageRules": [
           {
             "matchUpdateTypes": ["!major"],
             "groupName": "non-major dependencies",
             "schedule": ["* 0-5 * * 1"]
           },
           {
             "matchPackageNames": ["@lomray/*"],
             "matchUpdateTypes": ["!major"],
             "groupName": "Lomray dependencies",
             "schedule": ["* 0-5 * * 1"]
           },
           {"matchUpdateTypes": ["major"], "groupName": null}
         ]
       }
 INFO: Config validated successfully
```

- `npx --yes actionlint` → exit 1 because npm could not determine an executable. Workflow syntax was reviewed by reading only, including triggers, matrix expressions, checkout guards, and step conditions, against the [GitHub Actions workflow syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).

```text
npm error could not determine executable to run
npm error A complete log of this run can be found in: /Users/mikhail/.npm/_logs/2026-09-05T06_52_48_167Z-debug-0.log
```

- `npm run lint:check` → exit 0.

```text
> @lomray/vite-template@1.0.0 lint:check
> eslint "src/**/*.{ts,tsx,*.ts,*tsx}"
```

- `npm run ts:check` → exit 0.

```text
> @lomray/vite-template@1.0.0 ts:check
> tsc --project ./tsconfig.json --skipLibCheck --noemit
```

- `npm run style:check` → exit 0.

```text
> @lomray/vite-template@1.0.0 style:check
> stylelint "src/**/*.{css,scss}"
```

- `env -u NO_COLOR npm run build -- --throw-warnings` → exit 0, with no warnings. Output tail:

```text
build/server/assets/home-BWZVPehe.js                  4.88 kB │ gzip: 1.41 kB
build/server/assets/index-BYEH0oo6.js                 5.11 kB │ gzip: 1.73 kB
build/server/server.js                                9.61 kB │ gzip: 3.06 kB

✓ built in 123ms
Building routes manifest file

  SSR-BOOST  client,server built in 837 ms 
```

- Ran the exact branch-guard shell body extracted from `.github/workflows/example-check.yml` for all four matrix branches → each exited 0; only `prod` was present.

```text
$ BRANCH=prod bash -e /tmp/vite-template-t3.GXisLm/branch-guard.sh
713958ec57cdae8f257f00a7b1827c21da8e3211	refs/heads/prod
exists=true
Exit: 0
$ BRANCH=example/minimal bash -e /tmp/vite-template-t3.GXisLm/branch-guard.sh
Branch example/minimal does not exist yet; skipping.
exists=false
Exit: 0
$ BRANCH=example/custom-server bash -e /tmp/vite-template-t3.GXisLm/branch-guard.sh
Branch example/custom-server does not exist yet; skipping.
exists=false
Exit: 0
$ BRANCH=example/localization bash -e /tmp/vite-template-t3.GXisLm/branch-guard.sh
Branch example/localization does not exist yet; skipping.
exists=false
Exit: 0
```

- Checked the smoke-run server PIDs with `os.kill(pid, 0)` and their ports with `socket.connect_ex` → both processes were gone and both ports refused connections.

```text
SSR: PID 9279 no longer exists; port 54600 refuses connections.
SPA: PID 9538 no longer exists; port 54641 refuses connections.
```

- Failure-path proof: temporarily changed the first configured status from 200 to 201 and ran `npm run smoke` → exit 1 on that first check, no later route or SPA checks, and no remaining server. Restored the configuration byte for byte. Output tail and cleanup checks:

```text
  ➜  Local:   http://127.0.0.1:54795/


[smoke] Stopped SSR server (PID 10002).
[smoke] FAILED: SSR GET /: expected status 201.

200 !== 201
Exit: 1
No later route or SPA checks ran.
SSR PID 10002 no longer exists; port 54795 refuses connections.
Original smoke config restored byte for byte.
```

- `node --check scripts/smoke.mjs`, `sh -n .husky/commit-msg .husky/pre-commit`, and `git diff --check` → exit 0 with no output.
- `npx --no-install prettier --check scripts/smoke.mjs scripts/smoke.config.json renovate.json` → exit 0.

```text
Checking formatting...
All matched files use Prettier code style!
```

- `git commit -m "ci: check example branches and add renovate"` → exit 0 with hooks enabled. Verified the branch against the repository regex immediately before committing. Exactly one real commit is ahead of `origin/prod`; neither throwaway branch remains. `PR_DESCRIPTION.md` is untracked and absent from the commit.

```text
→ lint-staged could not find any staged files matching configured tasks.
[feature/example-branch-ci da68063] ci: check example branches and add renovate
 9 files changed, 406 insertions(+), 19 deletions(-)
 create mode 100644 .github/workflows/example-check.yml
 create mode 100644 renovate.json
 create mode 100644 scripts/smoke.config.json
 create mode 100644 scripts/smoke.mjs
Exit: 0
$ git branch --show-current
feature/example-branch-ci
$ git log --oneline origin/prod..HEAD
da68063 ci: check example branches and add renovate
$ git status --short
?? PR_DESCRIPTION.md
```

## Not run

- Browser checks: Not run. No browser is available.
- Automated workflow syntax validation: Not run. The requested `npx actionlint` invocation could not locate an executable; reading-only review is recorded above.
- GitHub-hosted workflow execution and Renovate PR creation: Not run. No push or pull request was made, as instructed.

## Open questions / Gap report

- The initial checkout had no `core.hooksPath`. Running the existing `npm run prepare` installed Husky at `.husky/_`; both proof commits and the real commit use the hooks.
- Renovate validated the required `baseBranches: ["prod"]` but reported `Config migration necessary`, proposing `baseBranchPatterns`. The requested field is retained. The current [Renovate configuration reference](https://docs.renovatebot.com/configuration-options/#basebranchpatterns) documents the replacement name.
- The validator invocation selected Renovate 42.99.0 and printed package deprecation warnings. These did not prevent validation and did not change repository dependencies.
- Demo streaming labels are preserved from the existing README. Live deployment behavior was not reverified. No `amplify.yml` was added.
- No library API gap was encountered. No task outside T3 was executed.
