### PR TITLE
chore: track example/minimal in renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | Branch | What it shows | When to start from it | Link |
 | --- | --- | --- | --- |
 | `prod` | Streaming SSR, MobX, consistent Suspense, meta tags and route management | Use the full reference app | [Browse](https://github.com/Lomray-Software/vite-template/tree/prod) |
-| `example/minimal` (planned) | Minimal SSR with loaders and route-level CSS | Start with a small SSR app once available | Planned |
+| `example/minimal` | Six runtime dependencies, loaders, a lazy route with CSS, redirect, client-only route and 404, plus the SPA-to-SSR file diff | Start with a small SSR app | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/minimal) |
 | `example/custom-server` (planned) | A custom Fastify server | Own the production server once available | Planned |
 | `example/localization` (planned) | Localization with server and client language state | Add localization once available | Planned |
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "baseBranches": ["prod"],
+  "baseBranches": ["prod", "example/minimal"],
   "rangeStrategy": "bump",
   "automerge": false,
   "labels": ["dependencies"],


### PR DESCRIPTION
Renovate now keeps example/minimal current alongside prod, and the README branch table links the merged example instead of marking it planned.