### PR TITLE
feat: custom Fastify server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,255 +1,191 @@
-# Minimal SSR example
+# Custom Fastify server example
 
-This is the `example/minimal` branch of vite-template, using React 19, React Router 8, Vite 8, and vite-ssr-boost 8 beta.
-The app uses React Router [Data mode](https://reactrouter.com/start/modes#data).
+This is the `example/custom-server` branch of vite-template.
+It extends [example/minimal](https://github.com/Lomray-Software/vite-template/tree/example/minimal) with a production server owned by the application.
+It uses React 19, React Router 8 [Data mode](https://reactrouter.com/start/modes#data), Vite 8, and vite-ssr-boost 8 beta.
 
-- Server-rendered pages with a title and description from a request-scoped meta manager.
-- Resolved loader data on `/users`, a user page on `/users/:id`, and a loader error boundary for unknown IDs.
-- A lazy `/about` route with its own CSS module injected into the server response.
-- A server-aware 301 redirect, a browser-only route with a fallback, and a 404 page.
-- Development reloads and SSR or SPA builds from the same application.
+- A named Fetch handler and a default managed CLI entry share the same app, routes, and metadata hooks.
+- Development uses the managed CLI and its Vite integration.
+- Production uses a plain JavaScript Fastify launcher, with static files, streaming compression, and Early Hints.
+- The lazy `/about` route receives its stylesheet in the server response.
+- The smoke script verifies the managed SSR server, Fastify SSR, and a managed SPA build.
 
-## From a plain Vite SPA to this project
+The routes are unchanged: `/`, `/users`, `/users/:id`, `/about`, `/redirect`, `/client-only`, and a catch-all 404.
+The pages retain the “Minimal SSR example” title so the two server paths render the same application.
+Loaders return resolved first-paint data. Nested loader promises serialize as `{}` in hydration data; use the [prod example](https://github.com/Lomray-Software/vite-template/tree/prod) for component-level Suspense with request-scoped state ([serializer](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/src/helpers/build-router-state.ts)).
 
-Use Node 22.23.2 (`.nvmrc`) and npm.
-The six direct runtime dependencies and their versions are listed in [package.json](package.json).
-They are `react`, `react-dom`, `react-router`, `@lomray/vite-ssr-boost`, `@lomray/react-head-manager`, and `isbot`.
-Keep vite-ssr-boost on the `^8.0.0-beta.5` range while using this example.
-The head manager also installs `@lomray/consistent-suspense` as a transitive peer dependency; application code does not import it.
+## Commands
 
-This comparison starts with Data-mode route objects, a shared `App` wrapper, and metadata already in the SPA.
-The shared files are [src/app.tsx](src/app.tsx), [src/routes/index.ts](src/routes/index.ts), [src/constants/state-key.ts](src/constants/state-key.ts), the pages, and [tsconfig.json](tsconfig.json).
-`App` accepts a meta manager through its `client` or `server` props and provides it to the route tree.
-If your SPA has no metadata provider, add that shared wrapper before applying these entry changes.
-The `.txt` files in [docs/spa-before](docs/spa-before) preserve the before sources at the target paths shown below; they are documentation fixtures, not a second application.
-The after blocks are copied from this branch's files, with no omitted lines.
+Use Node 22.23.2 (`.nvmrc`) and run `npm ci` from the repository root.
+[package.json](package.json) has eight direct runtime dependencies: the six from the minimal example plus `fastify` and `@fastify/static`.
+Fastify runs the HTTP server; its static plugin serves the browser build.
+The library range is `^8.0.0-beta.5`.
 
-### `vite.config.ts`
+These commands use the scripts in [package.json](package.json):
 
-Before — source: [docs/spa-before/vite.config.ts.txt](docs/spa-before/vite.config.ts.txt), copied to `vite.config.ts`.
+| Command | Result |
+| --- | --- |
+| `npm run develop` | Start the managed development server. |
+| `npm run build` | Build `build/client` and `build/server`. |
+| `npm run start:fastify` | Run `node server/index.mjs` against the SSR build. |
+| `npm run start:ssr` | Run the managed production server for comparison. |
+| `npm run build:spa` | Build the browser-only application. |
+| `npm run start:spa` | Serve the SPA build through the managed CLI. |
+| `npm run smoke` | Build and check both SSR servers, then build and check SPA. |
 
-```ts
-import devtoolsJson from 'vite-plugin-devtools-json';
-import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+Build SSR before starting Fastify. Set `PORT` to change its default port of 3000.
+The launcher binds all interfaces and handles `SIGINT` and `SIGTERM` by closing Fastify.
+For a development port override, put the same `VITE_PORT` value in `.env.development.local` and pass `-- --port` with that value to `npm run develop`.
+Rebuild SSR after running smoke, which finishes with a SPA build.
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  root: 'src',
-  publicDir: '../public',
-  envDir: '../',
-  resolve: { tsconfigPaths: true },
-  build: {
-    outDir: '../build',
-    emptyOutDir: true,
-  },
-  plugins: [devtoolsJson(), react()],
-});
-```
+## Dual-export pattern
 
-After — source: [vite.config.ts](vite.config.ts).
+The default export is an `entryServer` pipeline consumed by the managed CLI.
+The named `handler` is a Fetch request handler created with `createHandler`, `createStaticHandler`, and the Node stream renderer.
+Neither export starts an HTTP listener.
+Both paths use the same `App`, route objects, crawler policy, and metadata lifecycle.
+A new meta manager is created per request, and its state is restored by [src/client.ts](src/client.ts).
 
-```ts
-import SsrBoost from '@lomray/vite-ssr-boost/plugin';
-import devtoolsJson from 'vite-plugin-devtools-json';
-import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+The additional `configureHandler` export is application bootstrap glue.
+[server/index.mjs](server/index.mjs) supplies production `getHtml` and `prepare` hooks before accepting requests.
+The managed CLI provides its own HTML and asset preparation and does not call this function.
+The shared hooks use only the request, app props, and HTML fields present in both context types.
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  root: 'src',
-  publicDir: '../public',
-  envDir: '../',
-  build: {
-    outDir: '../build',
-  },
-  plugins: [devtoolsJson(), SsrBoost(), react()],
-});
-```
-
-`SsrBoost()` also reads the existing tsconfig aliases, so the before configuration’s `resolve.tsconfigPaths` is no longer needed.
-
-### `src/index.html`
-
-Before — source: [docs/spa-before/src/index.html.txt](docs/spa-before/src/index.html.txt), copied to `src/index.html`.
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/client.ts" async></script>
-  </body>
-</html>
-```
-
-After — source: [src/index.html](src/index.html).
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"><!--ssr-outlet--></div>
-    <script type="module" src="/client.ts" async></script>
-  </body>
-</html>
-```
-
-The only HTML change from the SPA is `<!--ssr-outlet-->`.
-
-### `src/client.ts`
-
-Before — source: [docs/spa-before/src/client.ts.txt](docs/spa-before/src/client.ts.txt), copied to `src/client.ts`.
-
-```ts
-import { Manager as MetaManager } from '@lomray/react-head-manager';
-import { createElement } from 'react';
-import { createRoot } from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router';
-import routes from '@routes/index';
-import App from './app';
-
-const router = createBrowserRouter(routes);
-const metaManager = new MetaManager();
-
-createRoot(document.getElementById('root')!).render(
-  createElement(App, { client: { metaManager } }, createElement(RouterProvider, { router })),
-);
-```
-
-After — source: [src/client.ts](src/client.ts).
-
-```ts
-import { Manager as MetaManager } from '@lomray/react-head-manager';
-import entryClient from '@lomray/vite-ssr-boost/browser/entry';
-import getServerState from '@lomray/vite-ssr-boost/helpers/get-server-state';
-import StateKey from '@constants/state-key';
-import routes from '@routes/index';
-import App from './app';
-
-void entryClient(App, routes, {
-  init: () =>
-    Promise.resolve({
-      metaManager: new MetaManager(getServerState(StateKey.metaManager, import.meta.env.PROD)),
-    }),
-});
-```
-
-### `src/server.ts`
-
-Before: no server entry exists in the SPA.
-
-After — source: [src/server.ts](src/server.ts).
+Source: [src/server.ts](src/server.ts), complete file.
 
 ```ts
 import { Manager as MetaManager } from '@lomray/react-head-manager';
 import MetaServer from '@lomray/react-head-manager/server';
 import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+import createHandler from '@lomray/vite-ssr-boost/core/handler';
+import type { ICreateHandlerOptions } from '@lomray/vite-ssr-boost/core/handler';
+import type { ISsrRequestContext } from '@lomray/vite-ssr-boost/core/render';
+import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
 import { isbot } from 'isbot';
+import { createElement } from 'react';
+import { createStaticHandler } from 'react-router';
 import StateKey from '@constants/state-key';
 import routes from '@routes/index';
 import App from './app';
 
-export default entryServer(App, routes, {
-  init: () => ({
-    onRequest: () => ({ appProps: { metaManager: new MetaManager() } }),
-    onRouterReady: ({ context: { request } }) => ({
-      isStream:
-        !isbot(request.headers.get('user-agent') ?? '') &&
-        !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
-    }),
-    onShellReady: ({ context: { appProps, html } }) => ({
-      header: MetaServer.inject(html.header, appProps.metaManager),
-    }),
-    getState: ({ context: { appProps } }) => ({
-      [StateKey.metaManager]: MetaServer.getState(appProps.metaManager),
-    }),
+type TServerOptions = ICreateHandlerOptions<{ metaManager: MetaManager }>;
+type THookParams = {
+  context: Pick<ISsrRequestContext<{ metaManager: MetaManager }>, 'request' | 'appProps' | 'html'>;
+};
+
+const hooks = {
+  onRouterReady: ({ context: { request } }: THookParams) => ({
+    isStream:
+      !isbot(request.headers.get('user-agent') ?? '') &&
+      !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
   }),
+  onShellReady: ({ context: { appProps, html } }: THookParams) => ({
+    header: MetaServer.inject(html.header, appProps.metaManager),
+  }),
+  getState: ({ context: { appProps } }: THookParams) => ({
+    [StateKey.metaManager]: MetaServer.getState(appProps.metaManager),
+  }),
+};
+const onRequest = () => ({ appProps: { metaManager: new MetaManager() } });
+let production: Pick<TServerOptions, 'getHtml' | 'prepare'>;
+
+// The production launcher supplies build assets once, before accepting requests.
+export const configureHandler = (options: NonNullable<typeof production>): void => {
+  production = options;
+};
+
+export const handler = createHandler(
+  {
+    createApp: (children, { appProps }) => createElement(App, { server: appProps }, children),
+    handler: createStaticHandler(routes),
+    renderToStream,
+  },
+  {
+    ...hooks,
+    onRequest,
+    getHtml: (request) => {
+      if (!production) {
+        throw new Error('Call configureHandler before serving the Fetch handler.');
+      }
+
+      return production.getHtml(request);
+    },
+    prepare: (params) => production.prepare?.(params),
+  },
+);
+
+export default entryServer(App, routes, {
+  init: () => ({ ...hooks, onRequest }),
 });
 ```
 
-A new meta manager is created for each request, its tags are injected before the shell, and its state is restored by the client entry.
-Crawler user agents or the `isCrawler=1` cookie select a complete response instead of streaming.
+## Development and production
 
-### `package.json scripts`
+Development runs `ssr-boost dev` through the default entry.
+The managed CLI owns Vite transforms, development assets, and HMR ([server lifecycle](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/docs/guide/server-lifecycle.md)).
+The custom launcher runs only after a build and has no build step of its own.
+It imports the named handler from `build/server/server.js`.
 
-Before — source: [docs/spa-before/package.json.txt](docs/spa-before/package.json.txt), copied to `package.json`.
+Production reads `build/client/index.html` once and splits it on `<!--ssr-outlet-->`.
+Each request gets a fresh HTML shell so route assets and metadata do not accumulate across requests.
+The `prepare` hook injects matched route assets through the library manifest service and forwards any Early Hints.
 
-```json
-{
-  "scripts": {
-    "develop": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
-  }
-}
+Source: [server/index.mjs](server/index.mjs), production hook setup.
+
+```js
+configureHandler({
+  getHtml: () => ({ header, footer }),
+  prepare: async ({ context, executionContext }) => {
+    const hints = manifest.injectAssets(context);
+
+    if (hints.has('Link')) {
+      await executionContext?.onEarlyHints?.(hints);
+    }
+  },
+});
 ```
 
-After — source: [package.json](package.json) (the complete `scripts` object; keep the dependency and tooling fields).
+Static files come from `build/client`, with `index: false` to keep `/` on the SSR path.
+`wildcard: false` registers the built files individually, leaving the wildcard route to the SSR adapter.
+Files in `/assets/` receive a one-year `maxAge` and `immutable`; other static files receive `max-age=0` ([static plugin options](https://github.com/fastify/fastify-static#options)).
+The wildcard uses `adapterFastify` with compression enabled.
+The adapter streams through the raw response, bypassing Fastify serialization and `onSend` hooks ([adapter behavior](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/docs/guide/runtime-adapters.md#adapters)).
 
-```json
-{
-  "scripts": {
-    "develop": "ssr-boost dev",
-    "build": "ssr-boost build",
-    "build:spa": "ssr-boost build --focus-only client",
-    "start:ssr": "ssr-boost start",
-    "start:spa": "ssr-boost start --focus-only client",
-    "preview": "ssr-boost preview",
-    "smoke": "node scripts/smoke.mjs",
-    "lint:check": "eslint \"src/**/*.{ts,tsx,*.ts,*tsx}\" --max-warnings=0",
-    "lint:format": "eslint --fix \"src/**/*.{ts,tsx,*.ts,*tsx}\"",
-    "style:check": "stylelint \"src/**/*.{css,scss}\"",
-    "style:format": "stylelint --fix \"src/**/*.{css,scss}\"",
-    "ts:check": "tsc --project ./tsconfig.json --skipLibCheck --noemit",
-    "prepare": "husky"
-  }
-}
-```
+## Swap the transport
 
-## Commands
+For Hono, keep the built `handler` and its production configuration.
+Replace the Fastify listener with a Hono app and use the default export from `@lomray/vite-ssr-boost/adapters/hono` on its catch-all route.
+Supply static-file serving and the runtime listener through [Hono's Node integration](https://hono.dev/docs/getting-started/nodejs), or your chosen runtime.
+See the [library adapters guide](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/docs/guide/runtime-adapters.md#adapters) and [Hono adapter test](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/__tests__/adapters/hono.ts).
 
-Run `npm ci` after cloning the branch.
-These commands call the scripts in [package.json](package.json):
+For native Node, keep the same production configuration and import the default adapter from `@lomray/vite-ssr-boost/adapters/node`.
+Wrap the Fetch handler with that adapter and pass the resulting listener to Node's HTTP server, with explicit error handling and compression enabled.
+Serve static files before SSR, or put asset delivery in a reverse proxy.
+See the [library adapters guide](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/docs/guide/runtime-adapters.md#adapters), [Node adapter test](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/__tests__/adapters/node.ts), and [Node HTTP server API](https://nodejs.org/docs/latest-v22.x/api/http.html#httpcreateserveroptions-requestlistener).
 
-| Command             | Result                                    |
-| ------------------- | ----------------------------------------- |
-| `npm run develop`   | Start the development server.             |
-| `npm run build`     | Build the server and browser output.      |
-| `npm run start:ssr` | Serve the SSR build.                      |
-| `npm run build:spa` | Build only the browser output.            |
-| `npm run start:spa` | Serve the SPA build.                      |
-| `npm run smoke`     | Build and verify both SSR and SPA output. |
+## Smoke configuration
 
-Run the matching build before starting a server; rebuild SSR after `npm run smoke`, which finishes with a SPA build.
-For a development port override, set `VITE_PORT` to the same port in `.env.development.local` and pass `-- --port` to `npm run develop`.
+[scripts/smoke.config.json](scripts/smoke.config.json) selects both `ssr-boost` and `fastify` in its `servers` array.
+[scripts/smoke.mjs](scripts/smoke.mjs) builds SSR once, checks the same routes, HEAD response, HTML chunks, and crawler output against each server, and stops each process.
+Fastify starts as `node server/index.mjs` with `PORT` set to a free port.
+The script then builds SPA and checks it with the managed server.
+Omitting `servers` preserves the managed SSR and SPA behavior used by other branches.
 
-This branch disables Vercel automatic deployments; the `prod` branch keeps the demo deployments.
+## Known limitations
 
-## Pitfalls
+The spike uses `@lomray/vite-ssr-boost@8.0.0-beta.5`. No library files were changed.
 
-- Browser globals: keep `window` out of module scope in server-imported code; use a lazy `onlyClient` route with a fallback for browser-only pages ([working route](src/routes/index.ts), [page](src/pages/client-only/index.tsx)).
-- Loader promises: await first-paint data before returning it, because nested promises become `{}` when `window.__staticRouterHydrationData` is serialized with `JSON.stringify`, so `<Await>` or `use()` cannot hydrate that data; streamed data needs component-level Suspense, a request-scoped cache, and `getState` ([serializer](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/src/helpers/build-router-state.ts), [resolved loader](src/pages/users/index.tsx), [streamed data example](https://github.com/Lomray-Software/vite-template/tree/prod)).
-- Dependency CSS: add packages that import CSS to `ssr.noExternal` when they need Vite's server transforms ([Vite SSR externals](https://vite.dev/guide/ssr.html#ssr-externals)).
-- Environment variables: read public values through `import.meta.env`, keep secrets out of `VITE_*`, and restart development after changing env files ([Vite env variables](https://vite.dev/guide/env-and-mode.html)).
-- Hydration mismatches: compare the initial browser render with the server HTML and check data, dates, randomness, and browser-dependent branches ([React hydration troubleshooting](https://react.dev/reference/react-dom/client/hydrateRoot#troubleshooting)).
+- Route assets require the deep imports `@lomray/vite-ssr-boost/services/server-config` and `@lomray/vite-ssr-boost/services/ssr-manifest`. `ServerConfig.init({ isProd: true, isOnlyClient: false })` and `SsrManifest.get(config).injectAssets(context)` work from plain `server/index.mjs`. Injection adds the lazy `/about` stylesheet and returns `Link` headers, forwarded through `executionContext.onEarlyHints`. No manual manifest parsing or tag generation was needed.
+- These services couple the launcher to managed-server configuration. Build discovery uses the working directory, so start this example from the repository root. `SsrManifest.get` is a process-wide singleton that retains the first configuration; this example serves one build per process. Proposed public helper: `createRouteAssetPreparer<TAppProps>(options: { buildDir: string; modulePreload?: boolean }): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']>`, exported from `@lomray/vite-ssr-boost/node/production`. It would load an independent manifest for the explicit build directory, inject matched route assets, and forward Early Hints without importing `services/*`.
+- HTML bootstrap is manual. The launcher reads `build/client/index.html` once, validates exactly one `<!--ssr-outlet-->`, and supplies a fresh `{ header, footer }` object for every request. The example's `configureHandler` installs `getHtml` and `prepare` before listening; it is application glue, not a library API. Proposed public helper: `loadHtmlShell(options: { indexFile: string; outlet?: string }): Promise<() => IHtmlShell>`, also exported from `@lomray/vite-ssr-boost/node/production`. It would perform that read, validation, split, and per-request copy.
+- Fastify owns static-file caching, listening, and shutdown. Its adapter owns streamed response compression. Development and HMR still use the managed CLI. Rebuild and restart production after changing the app or its assets.
+
+The proposed signatures describe missing public helpers. They are not implemented or importable in this beta.
 
 ## Need more?
 
-| Branch                                                                                               | What it shows                                                      |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [prod](https://github.com/Lomray-Software/vite-template/tree/prod)                                   | Streamed data, MobX, consistent Suspense, and deployment examples. |
-| [example/custom-server](https://github.com/Lomray-Software/vite-template/tree/example/custom-server) | Planned.                                                           |
-| [example/localization](https://github.com/Lomray-Software/vite-template/tree/example/localization)   | Planned.                                                           |
+| Branch | What it shows |
+| --- | --- |
+| [prod](https://github.com/Lomray-Software/vite-template/tree/prod) | Streamed data, MobX, consistent Suspense, and deployment examples. |
+| [example/minimal](https://github.com/Lomray-Software/vite-template/tree/example/minimal) | Six runtime dependencies and the complete SPA-to-SSR diff. |
+| [example/localization](https://github.com/Lomray-Software/vite-template/tree/example/localization) | Planned: locale selection and matching server/browser state. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "@lomray/vite-template",
       "version": "1.0.0",
       "dependencies": {
+        "@fastify/static": "^10.1.3",
         "@lomray/react-head-manager": "^2.1.1",
         "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+        "fastify": "^5.12.3",
         "isbot": "^5.2.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -1003,6 +1005,231 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.1.0.tgz",
+      "integrity": "sha512-F3EVbzWt+xcnVaOHmWyIlpuFtbxOln7HDZQsh09MtMmMm/CipMayNt8hnIL8VQi54u2ZociDbf+iluGYkf7B1A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.6.tgz",
+      "integrity": "sha512-NtuzM0SfaMJbGlnjr9LWQUN5LzgSrbB8tf/wRZNas+4E1O/Nmzl53e7ruT61HDZyRCJGC6FxIogmNZO1c5ETBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/fast-uri": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^7.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.2.tgz",
+      "integrity": "sha512-NE8HgKLgYejV9lDpqkEFaDKMLYelJBVfHekhB0UKvX0ghagXRJqg68feg8er1NPXxG4N9i6vPxzt8E+3wHfcmA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/proxy-addr/node_modules/ipaddr.js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@fastify/send": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.1.tgz",
+      "integrity": "sha512-BYo+EiaKwlxH+WetGk6hAs1d39iP0y1gqB8lGF/qwkJ9ZZ/cBY1vx5NvExb9Sc3yRMFjD5X4Eyh4e4+TzRkzdw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mime": "^3"
+      }
+    },
+    "node_modules/@fastify/send/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.3.tgz",
+      "integrity": "sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^13.0.0"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/content-disposition": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1287,6 +1514,15 @@
         "@types/serve-static": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1579,6 +1815,12 @@
       "funding": {
         "url": "https://github.com/sponsors/oxc-project"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@pkgr/core": {
       "version": "0.3.6",
@@ -3071,6 +3313,12 @@
         }
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3167,7 +3415,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3178,6 +3425,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -3286,6 +3550,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
@@ -3310,7 +3603,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3393,7 +3685,6 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4327,9 +4618,17 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-indent": {
@@ -4732,8 +5031,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5446,11 +5744,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -5497,6 +5800,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -5504,11 +5847,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
       "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5531,11 +5882,59 @@
         "node": ">= 4.9.1"
       }
     },
+    "node_modules/fastify": {
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.3.tgz",
+      "integrity": "sha512-reZ8wce5VNCcufIt9AVtzZa3L4u1j8esikn7OEgHWLVpRpL5R7Y2+Xzj70OUkv5zDfzUAxXZT6cu4Rt0zr3EKA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.1.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
       "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5617,6 +6016,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.9.0.tgz",
+      "integrity": "sha512-sJsgZ1sQH2UDuowPuMKg8az7Qc8F0jnj+SKkFWU/+T0xcFlgV5skgXOGUqmQzOdmW6ALA7AhJINWx3qFBkbLHA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -5869,6 +6282,23 @@
         "stream-combiner2": "~1.1.1",
         "through2": "~2.0.0",
         "traverse": "0.6.8"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -6252,7 +6682,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -6456,7 +6885,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -6786,11 +7214,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6902,6 +7348,56 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -7296,7 +7792,6 @@
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -7540,7 +8035,6 @@
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.8"
@@ -7560,6 +8054,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -9684,6 +10187,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -10007,6 +10519,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -10055,6 +10583,52 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/pkg-conf": {
       "version": "2.1.0",
@@ -10332,6 +10906,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -10437,6 +11027,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/quote-js-string": {
@@ -10665,6 +11261,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/refa": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
@@ -10732,7 +11337,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10771,16 +11375,30 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.2.7",
@@ -10877,6 +11495,37 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10904,6 +11553,22 @@
       "engines": {
         "node": "^14.0.0 || >=16.0.0"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semantic-release": {
       "version": "25.0.9",
@@ -11024,7 +11689,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11093,12 +11757,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11362,6 +12031,15 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11449,7 +12127,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -12045,6 +12722,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -12111,12 +12806,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.6"
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "ssr-boost build",
     "build:spa": "ssr-boost build --focus-only client",
     "start:ssr": "ssr-boost start",
+    "start:fastify": "node server/index.mjs",
     "start:spa": "ssr-boost start --focus-only client",
     "preview": "ssr-boost preview",
     "smoke": "node scripts/smoke.mjs",
@@ -18,8 +19,10 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@fastify/static": "^10.1.3",
     "@lomray/react-head-manager": "^2.1.1",
     "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+    "fastify": "^5.12.3",
     "isbot": "^5.2.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/scripts/smoke.config.json
+++ b/scripts/smoke.config.json
@@ -33,5 +33,6 @@
     }
   ],
   "streamPath": "/about",
-  "crawlerCookie": "isCrawler=1"
+  "crawlerCookie": "isCrawler=1",
+  "servers": ["ssr-boost", "fastify"]
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -31,9 +31,9 @@ const getPort = async () => {
   return port;
 };
 
-const startProcess = (command, args) => {
+const startProcess = (command, args, env = process.env) => {
   assert.ok(!interrupted, 'Smoke check interrupted.');
-  const child = spawn(command, args, { cwd: root, stdio: 'inherit', detached: true });
+  const child = spawn(command, args, { cwd: root, stdio: 'inherit', detached: true, env });
   const processState = { child, result: null, done: null, stopping: null };
 
   processState.done = new Promise((resolve) => {
@@ -153,10 +153,13 @@ const waitUntilReady = async (origin, state) => {
   throw new Error(`Server did not become ready within 30 seconds: ${origin}`);
 };
 
-const withServer = async (mode, args, verify) => {
+const withServer = async (mode, args, verify, server = 'ssr-boost') => {
   const port = await getPort();
   const origin = `http://127.0.0.1:${port}`;
-  const state = startProcess(process.execPath, [cli, 'start', ...args, '--port', String(port)]);
+  const state =
+    server === 'fastify'
+      ? startProcess(process.execPath, ['server/index.mjs'], { ...process.env, PORT: String(port) })
+      : startProcess(process.execPath, [cli, 'start', ...args, '--port', String(port)]);
 
   console.info(`[smoke] Starting ${mode} server on port ${port} (PID ${state.child.pid}).`);
 
@@ -173,7 +176,7 @@ try {
   const config = JSON.parse(
     await readFile(new URL('./smoke.config.json', import.meta.url), 'utf8'),
   );
-  const { routes, streamPath, crawlerCookie } = config;
+  const { routes, streamPath, crawlerCookie, servers = ['ssr-boost'] } = config;
 
   assert.ok(Array.isArray(routes) && routes.length > 0, 'Configure at least one smoke route.');
   assert.ok(typeof streamPath === 'string' && streamPath.startsWith('/'), 'Configure streamPath.');
@@ -182,47 +185,65 @@ try {
     'Configure crawlerCookie.',
   );
 
+  assert.ok(
+    Array.isArray(servers) &&
+      servers.length > 0 &&
+      servers.every((server) => ['ssr-boost', 'fastify'].includes(server)),
+    'Configure servers as a nonempty array containing ssr-boost or fastify.',
+  );
+
   await build();
-  await withServer('SSR', [], async (origin) => {
-    for (const { path, status, contains = [], headers = {} } of routes) {
-      const response = await inspect(origin, path, { headers });
+  for (const server of servers) {
+    const mode = `SSR (${server})`;
 
-      assert.equal(response.status, status, `SSR GET ${path}: expected status ${status}.`);
-      for (const marker of contains) {
+    await withServer(
+      mode,
+      [],
+      async (origin) => {
+        for (const { path, status, contains = [], headers = {} } of routes) {
+          const response = await inspect(origin, path, { headers });
+
+          assert.equal(response.status, status, `${mode} GET ${path}: expected status ${status}.`);
+          for (const marker of contains) {
+            assert.ok(
+              response.html.includes(marker),
+              `${mode} GET ${path}: missing ${JSON.stringify(marker)}.`,
+            );
+          }
+
+          console.info(
+            `[smoke] ${mode} GET ${path}: ${status}; ${contains.length} content checks passed.`,
+          );
+        }
+
+        const first = routes[0];
+        const head = await inspect(origin, first.path, { method: 'HEAD', headers: first.headers });
+
+        assert.equal(head.status, first.status, `${mode} HEAD ${first.path}: unexpected status.`);
+        assert.equal(head.html, '', `${mode} HEAD ${first.path}: expected an empty body.`);
+        console.info(`[smoke] ${mode} HEAD ${first.path}: ${head.status}; empty body.`);
+
+        const streamed = await inspect(origin, streamPath);
+
+        assert.equal(streamed.status, 200, `${mode} stream ${streamPath}: expected status 200.`);
         assert.ok(
-          response.html.includes(marker),
-          `SSR GET ${path}: missing ${JSON.stringify(marker)}.`,
+          streamed.chunks > 1,
+          `${mode} stream ${streamPath}: expected more than one HTML chunk, got ${streamed.chunks}.`,
         );
-      }
+        console.info(`[smoke] ${mode} stream ${streamPath}: ${streamed.chunks} HTML chunks.`);
 
-      console.info(`[smoke] SSR GET ${path}: ${status}; ${contains.length} content checks passed.`);
-    }
+        const crawler = await inspect(origin, streamPath, { headers: { Cookie: crawlerCookie } });
 
-    const first = routes[0];
-    const head = await inspect(origin, first.path, { method: 'HEAD', headers: first.headers });
-
-    assert.equal(head.status, first.status, `SSR HEAD ${first.path}: unexpected status.`);
-    assert.equal(head.html, '', `SSR HEAD ${first.path}: expected an empty body.`);
-    console.info(`[smoke] SSR HEAD ${first.path}: ${head.status}; empty body.`);
-
-    const streamed = await inspect(origin, streamPath);
-
-    assert.equal(streamed.status, 200, `SSR stream ${streamPath}: expected status 200.`);
-    assert.ok(
-      streamed.chunks > 1,
-      `SSR stream ${streamPath}: expected more than one HTML chunk, got ${streamed.chunks}.`,
+        assert.equal(crawler.status, 200, `${mode} crawler ${streamPath}: expected status 200.`);
+        assert.ok(
+          !crawler.html.includes('<!--$?-->'),
+          `${mode} crawler ${streamPath}: pending Suspense boundary.`,
+        );
+        console.info(`[smoke] ${mode} crawler ${streamPath}: 200; no pending Suspense boundaries.`);
+      },
+      server,
     );
-    console.info(`[smoke] SSR stream ${streamPath}: ${streamed.chunks} HTML chunks.`);
-
-    const crawler = await inspect(origin, streamPath, { headers: { Cookie: crawlerCookie } });
-
-    assert.equal(crawler.status, 200, `SSR crawler ${streamPath}: expected status 200.`);
-    assert.ok(
-      !crawler.html.includes('<!--$?-->'),
-      `SSR crawler ${streamPath}: pending Suspense boundary.`,
-    );
-    console.info(`[smoke] SSR crawler ${streamPath}: 200; no pending Suspense boundaries.`);
-  });
+  }
 
   await build(['--focus-only', 'client']);
   await withServer('SPA', ['--focus-only', 'client'], async (origin) => {

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,0 +1,60 @@
+import { readFile } from 'node:fs/promises';
+import { join, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fastifyStatic from '@fastify/static';
+import adapterFastify from '@lomray/vite-ssr-boost/adapters/fastify';
+import ServerConfig from '@lomray/vite-ssr-boost/services/server-config';
+import SsrManifest from '@lomray/vite-ssr-boost/services/ssr-manifest';
+import Fastify from 'fastify';
+import { configureHandler, handler } from '../build/server/server.js';
+
+const clientDir = fileURLToPath(new URL('../build/client/', import.meta.url));
+const parts = (await readFile(join(clientDir, 'index.html'), 'utf8')).split('<!--ssr-outlet-->');
+
+if (parts.length !== 2) {
+  throw new Error('Build SSR output with npm run build before starting Fastify.');
+}
+
+const [header, footer] = parts;
+const config = ServerConfig.init({ isProd: true, isOnlyClient: false });
+const manifest = SsrManifest.get(config);
+
+configureHandler({
+  getHtml: () => ({ header, footer }),
+  prepare: async ({ context, executionContext }) => {
+    const hints = manifest.injectAssets(context);
+
+    if (hints.has('Link')) {
+      await executionContext?.onEarlyHints?.(hints);
+    }
+  },
+});
+
+const app = Fastify();
+
+await app.register(fastifyStatic, {
+  root: clientDir,
+  index: false,
+  wildcard: false,
+  immutable: true,
+  maxAge: '1y',
+  setHeaders: (reply, filePath) => {
+    if (!filePath.startsWith(`${join(clientDir, 'assets')}${sep}`)) {
+      reply.header('Cache-Control', 'public, max-age=0');
+    }
+  },
+});
+app.all('/*', adapterFastify(handler, { compression: true }));
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, () => {
+    void app.close().catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  });
+}
+
+const address = await app.listen({ port: Number(process.env.PORT ?? 3000), host: '0.0.0.0' });
+
+console.info(`Fastify listening at ${address}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,24 +1,63 @@
 import { Manager as MetaManager } from '@lomray/react-head-manager';
 import MetaServer from '@lomray/react-head-manager/server';
 import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+import createHandler from '@lomray/vite-ssr-boost/core/handler';
+import type { ICreateHandlerOptions } from '@lomray/vite-ssr-boost/core/handler';
+import type { ISsrRequestContext } from '@lomray/vite-ssr-boost/core/render';
+import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
 import { isbot } from 'isbot';
+import { createElement } from 'react';
+import { createStaticHandler } from 'react-router';
 import StateKey from '@constants/state-key';
 import routes from '@routes/index';
 import App from './app';
 
-export default entryServer(App, routes, {
-  init: () => ({
-    onRequest: () => ({ appProps: { metaManager: new MetaManager() } }),
-    onRouterReady: ({ context: { request } }) => ({
-      isStream:
-        !isbot(request.headers.get('user-agent') ?? '') &&
-        !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
-    }),
-    onShellReady: ({ context: { appProps, html } }) => ({
-      header: MetaServer.inject(html.header, appProps.metaManager),
-    }),
-    getState: ({ context: { appProps } }) => ({
-      [StateKey.metaManager]: MetaServer.getState(appProps.metaManager),
-    }),
+type TServerOptions = ICreateHandlerOptions<{ metaManager: MetaManager }>;
+type THookParams = {
+  context: Pick<ISsrRequestContext<{ metaManager: MetaManager }>, 'request' | 'appProps' | 'html'>;
+};
+
+const hooks = {
+  onRouterReady: ({ context: { request } }: THookParams) => ({
+    isStream:
+      !isbot(request.headers.get('user-agent') ?? '') &&
+      !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
   }),
+  onShellReady: ({ context: { appProps, html } }: THookParams) => ({
+    header: MetaServer.inject(html.header, appProps.metaManager),
+  }),
+  getState: ({ context: { appProps } }: THookParams) => ({
+    [StateKey.metaManager]: MetaServer.getState(appProps.metaManager),
+  }),
+};
+const onRequest = () => ({ appProps: { metaManager: new MetaManager() } });
+let production: Pick<TServerOptions, 'getHtml' | 'prepare'>;
+
+// The production launcher supplies build assets once, before accepting requests.
+export const configureHandler = (options: NonNullable<typeof production>): void => {
+  production = options;
+};
+
+export const handler = createHandler(
+  {
+    createApp: (children, { appProps }) => createElement(App, { server: appProps }, children),
+    handler: createStaticHandler(routes),
+    renderToStream,
+  },
+  {
+    ...hooks,
+    onRequest,
+    getHtml: (request) => {
+      if (!production) {
+        throw new Error('Call configureHandler before serving the Fetch handler.');
+      }
+
+      return production.getHtml(request);
+    },
+    prepare: (params) => production.prepare?.(params),
+  },
+);
+
+export default entryServer(App, routes, {
+  init: () => ({ ...hooks, onRequest }),
 });


### PR DESCRIPTION
## Goal

`example/custom-server`: what vite-ssr-boost 8 adds beyond the managed CLI. Development still runs through `ssr-boost dev`; production runs a Fastify server the application owns, built on the Fetch handler and the Fastify adapter.

## What the branch contains

- `src/server.ts` exports both the managed entry (default, for the CLI) and a named `handler` built with `createHandler` + `createStaticHandler(routes)` + `renderToStream`, sharing the app, routes and head-manager hooks. `configureHandler` lets the production launcher supply the HTML shell and the asset injector once before serving.
- `server/index.mjs` (60 lines): Fastify 5, `@fastify/static` serving `build/client` (`index: false`, immutable one-year caching for `/assets/`), `adapterFastify(handler, { compression: true })` for everything else; reads `build/client/index.html` once and splits it on `<!--ssr-outlet-->`; injects route assets through `ServerConfig.init({ isProd: true })` + `SsrManifest.get(config).injectAssets(...)` and forwards Early Hints; graceful shutdown on SIGINT/SIGTERM. `npm run start:fastify`.
- `scripts/smoke.mjs` accepts `"servers": ["ssr-boost", "fastify"]` in the smoke config and runs the route checks against both servers; branches without the key keep the old behavior.
- README: the dual-export pattern and why, how development and production differ, how to swap Fastify for Hono or the Node adapter, known limitations (the gap report), the "Need more?" table.

## Gap report (library follow-ups)

- Route-asset injection needs the deep imports `@lomray/vite-ssr-boost/services/server-config` and `.../services/ssr-manifest`, which couple the launcher to the managed server's configuration (working-directory build discovery, process-wide manifest singleton). Proposed public helper: `createRouteAssetPreparer({ buildDir, modulePreload? })` exported from `@lomray/vite-ssr-boost/node/production`.
- Reading and splitting `index.html` is application glue. Proposed helper: `loadHtmlShell({ indexFile, outlet? })` from the same entry.

## Verification

- Acceptance script: dependency set (six + `fastify`, `@fastify/static`), lint (`--max-warnings=0`, `eslint .`), ts, style, `build --throw-warnings` with zero warnings, `npm run smoke` on both servers, Fastify curl matrix (`/about` stylesheet link, hydration data, HEAD with empty body, gzip with a complete decompressed document, 301 with `Location`, 404s, `immutable` cache-control on assets, crawler cookie without pending Suspense), `npm run develop` through the CLI: all pass.
- Browser (Chrome, Fastify server): hydration without console output, client-side navigation without reloads, lazy `/about` CSS applied on direct load, `/client-only` renders browser-only content.
