### PR TITLE
feat: localization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,255 +1,102 @@
-# Minimal SSR example
+# Localization example
 
-This is the `example/minimal` branch of vite-template, using React 19, React Router 8, Vite 8, and vite-ssr-boost 8 beta.
-The app uses React Router [Data mode](https://reactrouter.com/start/modes#data).
+This is the `example/localization` branch of vite-template. It adds i18next to
+[`example/minimal`](https://github.com/Lomray-Software/vite-template/tree/example/minimal).
 
-- Server-rendered pages with a title and description from a request-scoped meta manager.
-- Resolved loader data on `/users`, a user page on `/users/:id`, and a loader error boundary for unknown IDs.
-- A lazy `/about` route with its own CSS module injected into the server response.
-- A server-aware 301 redirect, a browser-only route with a fallback, and a 404 page.
-- Development reloads and SSR or SPA builds from the same application.
+- English and Spanish headings, descriptions, and navigation on the home, users, about, and not-found pages.
+- An i18next instance for each server request, supplied through `I18nextProvider`.
+- Bundled JSON namespaces with TypeScript translation-key checking.
+- Language transfer through the SSR state and bundled resources initialized before hydration.
+- A language switcher that saves a cookie and reloads the current URL.
 
-## From a plain Vite SPA to this project
+The minimal routes remain: `/`, `/users`, `/users/:id`, `/about`, `/redirect`,
+`/client-only`, and the not-found route. The users loader resolves its data before
+rendering. The about route loads lazily and includes its own stylesheet. The user
+profile and browser-only demonstrations keep their English copy.
 
-Use Node 22.23.2 (`.nvmrc`) and npm.
-The six direct runtime dependencies and their versions are listed in [package.json](package.json).
-They are `react`, `react-dom`, `react-router`, `@lomray/vite-ssr-boost`, `@lomray/react-head-manager`, and `isbot`.
-Keep vite-ssr-boost on the `^8.0.0-beta.5` range while using this example.
-The head manager also installs `@lomray/consistent-suspense` as a transitive peer dependency; application code does not import it.
+## Language selection
 
-This comparison starts with Data-mode route objects, a shared `App` wrapper, and metadata already in the SPA.
-The shared files are [src/app.tsx](src/app.tsx), [src/routes/index.ts](src/routes/index.ts), [src/constants/state-key.ts](src/constants/state-key.ts), the pages, and [tsconfig.json](tsconfig.json).
-`App` accepts a meta manager through its `client` or `server` props and provides it to the route tree.
-If your SPA has no metadata provider, add that shared wrapper before applying these entry changes.
-The `.txt` files in [docs/spa-before](docs/spa-before) preserve the before sources at the target paths shown below; they are documentation fixtures, not a second application.
-The after blocks are copied from this branch's files, with no omitted lines.
+`src/common/services/localization.ts` selects the language on the server:
 
-### `vite.config.ts`
+1. A supported value in the `lang` cookie wins.
+2. Otherwise, the first supported language in `Accept-Language` wins, in header order.
+3. Otherwise, the language is `en`.
 
-Before — source: [docs/spa-before/vite.config.ts.txt](docs/spa-before/vite.config.ts.txt), copied to `vite.config.ts`.
+The supported languages are `en` and `es`. Regional tags such as `es-MX` resolve to
+`es`, and matching ignores case. Unsupported languages, malformed cookie encoding,
+and header entries with `q=0` are skipped. Preferences are not sorted by quality;
+the first supported, non-excluded entry wins.
 
-```ts
-import devtoolsJson from 'vite-plugin-devtools-json';
-import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+`src/server.ts` initializes localization before rendering each request. The same
+instance supplies the page translations and the `<html lang>` attribute. Each
+request gets its own instance and a copy of the resources, so concurrent requests
+can use different languages.
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  root: 'src',
-  publicDir: '../public',
-  envDir: '../',
-  resolve: { tsconfigPaths: true },
-  build: {
-    outDir: '../build',
-    emptyOutDir: true,
-  },
-  plugins: [devtoolsJson(), react()],
-});
-```
+## Resources and typing
 
-After — source: [vite.config.ts](vite.config.ts).
+`src/assets/locales/namespaces.ts` statically imports `translation.json` and
+`forms.json` from `src/assets/locales/en` and `src/assets/locales/es`. These namespace names
+and the original `checkIt` and `firstName` keys come from the old localization
+branch. The Spanish sample strings are corrected. `types/i18next.d.ts` uses the
+English resource shape to type translation keys and declares `translation` as the
+default namespace. The JSON files are source modules and are not published as
+standalone static assets.
 
-```ts
-import SsrBoost from '@lomray/vite-ssr-boost/plugin';
-import devtoolsJson from 'vite-plugin-devtools-json';
-import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+The only added runtime dependencies are `i18next` and `react-i18next`.
+`i18next-http-backend` is omitted because the resources are bundled and available
+before the first render. No translation HTTP request is needed. A browser language
+detector is also unnecessary because the server chooses the SSR language.
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  root: 'src',
-  publicDir: '../public',
-  envDir: '../',
-  build: {
-    outDir: '../build',
-  },
-  plugins: [devtoolsJson(), SsrBoost(), react()],
-});
-```
+## State transfer and hydration
 
-`SsrBoost()` also reads the existing tsconfig aliases, so the before configuration’s `resolve.tsconfigPaths` is no longer needed.
+`src/server.ts` returns only `{ language }` from `getState` under
+`StateKey.localization`, next to `StateKey.metaManager`. `src/client.ts` reads the
+selected language and initializes i18next with that language and the statically
+imported resources inside the client entry's `init` callback. The entry awaits
+initialization before hydrating the app. The translation resources are already in
+the client bundle, so they are not duplicated in the HTML state.
 
-### `src/index.html`
+The server and client must agree on the language and resources before hydration.
+Otherwise, the client's first render can produce different text from the existing
+server HTML and cause a hydration mismatch. SSR startup therefore uses the
+transferred language without detecting the browser language again. Both entries
+import the same bundled resources. Separate instances use the
+[i18next `createInstance` API](https://www.i18next.com/overview/api#createinstance).
 
-Before — source: [docs/spa-before/src/index.html.txt](docs/spa-before/src/index.html.txt), copied to `src/index.html`.
+For a SPA build, there is no server localization state. The client instead uses
+the `lang` cookie, then `navigator.languages`, then English, and initializes the
+bundled resources before mounting. It also sets `document.documentElement.lang`.
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/client.ts" async></script>
-  </body>
-</html>
-```
+## Switcher
 
-After — source: [src/index.html](src/index.html).
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"><!--ssr-outlet--></div>
-    <script type="module" src="/client.ts" async></script>
-  </body>
-</html>
-```
-
-The only HTML change from the SPA is `<!--ssr-outlet-->`.
-
-### `src/client.ts`
-
-Before — source: [docs/spa-before/src/client.ts.txt](docs/spa-before/src/client.ts.txt), copied to `src/client.ts`.
-
-```ts
-import { Manager as MetaManager } from '@lomray/react-head-manager';
-import { createElement } from 'react';
-import { createRoot } from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router';
-import routes from '@routes/index';
-import App from './app';
-
-const router = createBrowserRouter(routes);
-const metaManager = new MetaManager();
-
-createRoot(document.getElementById('root')!).render(
-  createElement(App, { client: { metaManager } }, createElement(RouterProvider, { router })),
-);
-```
-
-After — source: [src/client.ts](src/client.ts).
-
-```ts
-import { Manager as MetaManager } from '@lomray/react-head-manager';
-import entryClient from '@lomray/vite-ssr-boost/browser/entry';
-import getServerState from '@lomray/vite-ssr-boost/helpers/get-server-state';
-import StateKey from '@constants/state-key';
-import routes from '@routes/index';
-import App from './app';
-
-void entryClient(App, routes, {
-  init: () =>
-    Promise.resolve({
-      metaManager: new MetaManager(getServerState(StateKey.metaManager, import.meta.env.PROD)),
-    }),
-});
-```
-
-### `src/server.ts`
-
-Before: no server entry exists in the SPA.
-
-After — source: [src/server.ts](src/server.ts).
-
-```ts
-import { Manager as MetaManager } from '@lomray/react-head-manager';
-import MetaServer from '@lomray/react-head-manager/server';
-import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
-import { isbot } from 'isbot';
-import StateKey from '@constants/state-key';
-import routes from '@routes/index';
-import App from './app';
-
-export default entryServer(App, routes, {
-  init: () => ({
-    onRequest: () => ({ appProps: { metaManager: new MetaManager() } }),
-    onRouterReady: ({ context: { request } }) => ({
-      isStream:
-        !isbot(request.headers.get('user-agent') ?? '') &&
-        !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
-    }),
-    onShellReady: ({ context: { appProps, html } }) => ({
-      header: MetaServer.inject(html.header, appProps.metaManager),
-    }),
-    getState: ({ context: { appProps } }) => ({
-      [StateKey.metaManager]: MetaServer.getState(appProps.metaManager),
-    }),
-  }),
-});
-```
-
-A new meta manager is created for each request, its tags are injected before the shell, and its state is restored by the client entry.
-Crawler user agents or the `isCrawler=1` cookie select a complete response instead of streaming.
-
-### `package.json scripts`
-
-Before — source: [docs/spa-before/package.json.txt](docs/spa-before/package.json.txt), copied to `package.json`.
-
-```json
-{
-  "scripts": {
-    "develop": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
-  }
-}
-```
-
-After — source: [package.json](package.json) (the complete `scripts` object; keep the dependency and tooling fields).
-
-```json
-{
-  "scripts": {
-    "develop": "ssr-boost dev",
-    "build": "ssr-boost build",
-    "build:spa": "ssr-boost build --focus-only client",
-    "start:ssr": "ssr-boost start",
-    "start:spa": "ssr-boost start --focus-only client",
-    "preview": "ssr-boost preview",
-    "smoke": "node scripts/smoke.mjs",
-    "lint:check": "eslint \"src/**/*.{ts,tsx,*.ts,*tsx}\" --max-warnings=0",
-    "lint:format": "eslint --fix \"src/**/*.{ts,tsx,*.ts,*tsx}\"",
-    "style:check": "stylelint \"src/**/*.{css,scss}\"",
-    "style:format": "stylelint --fix \"src/**/*.{css,scss}\"",
-    "ts:check": "tsc --project ./tsconfig.json --skipLibCheck --noemit",
-    "prepare": "husky"
-  }
-}
-```
+`src/common/components/layouts/app/index.tsx` renders English and Español buttons.
+A click sets `lang=en` or `lang=es` with `Path=/`, `SameSite=Lax`, and a one-year
+lifetime, then reloads the current URL. The next SSR request uses that cookie.
+The active button exposes its selection through `aria-pressed`. Switching requires
+JavaScript after startup. URLs do not have language prefixes.
 
 ## Commands
 
-Run `npm ci` after cloning the branch.
-These commands call the scripts in [package.json](package.json):
+Use Node 22.23.2 and install with `npm ci`. The scripts below are defined in
+`package.json`.
 
-| Command             | Result                                    |
-| ------------------- | ----------------------------------------- |
-| `npm run develop`   | Start the development server.             |
-| `npm run build`     | Build the server and browser output.      |
-| `npm run start:ssr` | Serve the SSR build.                      |
-| `npm run build:spa` | Build only the browser output.            |
-| `npm run start:spa` | Serve the SPA build.                      |
-| `npm run smoke`     | Build and verify both SSR and SPA output. |
+| Command                             | Purpose                                                                        |
+| ----------------------------------- | ------------------------------------------------------------------------------ |
+| `npm run develop`                   | Start the managed development server.                                          |
+| `npm run build -- --throw-warnings` | Build SSR output and reject warnings.                                          |
+| `npm run start:ssr -- --port 3000`  | Serve the SSR build.                                                           |
+| `npm run build:spa`                 | Build the browser app without SSR.                                             |
+| `npm run start:spa -- --port 3000`  | Serve the SPA build.                                                           |
+| `npm run smoke`                     | Build and check SSR routes, language headers, cookie priority, and SPA output. |
 
-Run the matching build before starting a server; rebuild SSR after `npm run smoke`, which finishes with a SPA build.
-For a development port override, set `VITE_PORT` to the same port in `.env.development.local` and pass `-- --port` to `npm run develop`.
-
-This branch disables Vercel automatic deployments; the `prod` branch keeps the demo deployments.
-
-## Pitfalls
-
-- Browser globals: keep `window` out of module scope in server-imported code; use a lazy `onlyClient` route with a fallback for browser-only pages ([working route](src/routes/index.ts), [page](src/pages/client-only/index.tsx)).
-- Loader promises: await first-paint data before returning it, because nested promises become `{}` when `window.__staticRouterHydrationData` is serialized with `JSON.stringify`, so `<Await>` or `use()` cannot hydrate that data; streamed data needs component-level Suspense, a request-scoped cache, and `getState` ([serializer](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/src/helpers/build-router-state.ts), [resolved loader](src/pages/users/index.tsx), [streamed data example](https://github.com/Lomray-Software/vite-template/tree/prod)).
-- Dependency CSS: add packages that import CSS to `ssr.noExternal` when they need Vite's server transforms ([Vite SSR externals](https://vite.dev/guide/ssr.html#ssr-externals)).
-- Environment variables: read public values through `import.meta.env`, keep secrets out of `VITE_*`, and restart development after changing env files ([Vite env variables](https://vite.dev/guide/env-and-mode.html)).
-- Hydration mismatches: compare the initial browser render with the server HTML and check data, dates, randomness, and browser-dependent branches ([React hydration troubleshooting](https://react.dev/reference/react-dom/client/hydrateRoot#troubleshooting)).
+The smoke configuration accepts an optional `headers` object per route. Existing
+route checks without headers still work. The script builds SPA output last; run
+`npm run build` again before starting an SSR server afterwards.
 
 ## Need more?
 
-| Branch                                                                                               | What it shows                                                      |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [prod](https://github.com/Lomray-Software/vite-template/tree/prod)                                   | Streamed data, MobX, consistent Suspense, and deployment examples. |
-| [example/custom-server](https://github.com/Lomray-Software/vite-template/tree/example/custom-server) | Planned.                                                           |
-| [example/localization](https://github.com/Lomray-Software/vite-template/tree/example/localization)   | Planned.                                                           |
+| Branch                                                                                                 | What it shows                                                 |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| [`prod`](https://github.com/Lomray-Software/vite-template/tree/prod)                                   | Streamed data, MobX, and consistent Suspense.                 |
+| [`example/minimal`](https://github.com/Lomray-Software/vite-template/tree/example/minimal)             | The minimal SSR app without localization.                     |
+| [`example/custom-server`](https://github.com/Lomray-Software/vite-template/tree/example/custom-server) | A custom production server using a Fetch handler and Fastify. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@lomray/react-head-manager": "^2.1.1",
         "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+        "i18next": "^26.4.2",
         "isbot": "^5.2.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-i18next": "^17.0.13",
         "react-router": "^8.3.1"
       },
       "devDependencies": {
@@ -164,6 +166,15 @@
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6172,6 +6183,15 @@
         "htmlparser2": "10.1.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://locize.com"
+      }
+    },
     "node_modules/html-react-parser": {
       "version": "5.2.17",
       "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.17.tgz",
@@ -6322,6 +6342,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.2.tgz",
+      "integrity": "sha512-RX+R0VLg13IbvRuJSxnqykUFS9vQZTl8wYpWPCIUDWVrSGjsQywB5Y+pjzrkboxGAuYfJZVH1InFTdgBdxq6ug==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -10526,6 +10574,33 @@
         "react": "^19.2.8"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.13.tgz",
+      "integrity": "sha512-Cc1PscmblIHA1kljTqDwrcVMI21ydgmUzw0UAeQBe7pAOgfuRLfzXze4EUBQoeDiICzFIXXhHFoZxuetNg5D0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "html-parse-stringify": "^4.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -12235,7 +12310,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12453,6 +12528,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   "dependencies": {
     "@lomray/react-head-manager": "^2.1.1",
     "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+    "i18next": "^26.4.2",
     "isbot": "^5.2.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-i18next": "^17.0.13",
     "react-router": "^8.3.1"
   },
   "devDependencies": {

--- a/scripts/smoke.config.json
+++ b/scripts/smoke.config.json
@@ -3,7 +3,53 @@
     {
       "path": "/",
       "status": 200,
-      "contains": ["Minimal SSR example", "window.__staticRouterHydrationData"]
+      "contains": [
+        "Minimal SSR example",
+        "window.__staticRouterHydrationData",
+        "<h1>Minimal SSR example</h1>",
+        "<html lang=\"en\""
+      ]
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "headers": {
+        "Accept-Language": "es"
+      },
+      "contains": ["<h1>Ejemplo mínimo de SSR</h1>", "<html lang=\"es\""]
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "headers": {
+        "Cookie": "lang=es",
+        "Accept-Language": "en"
+      },
+      "contains": ["<h1>Ejemplo mínimo de SSR</h1>", "<html lang=\"es\""]
+    },
+    {
+      "path": "/about",
+      "status": 200,
+      "headers": {
+        "Accept-Language": "es"
+      },
+      "contains": ["<h1>Acerca de este ejemplo</h1>", "rel=\"stylesheet\"", "<html lang=\"es\""]
+    },
+    {
+      "path": "/users",
+      "status": 200,
+      "headers": {
+        "Accept-Language": "es"
+      },
+      "contains": ["<h1>Usuarios</h1>", "Ada Lovelace"]
+    },
+    {
+      "path": "/missing",
+      "status": 404,
+      "headers": {
+        "Accept-Language": "es"
+      },
+      "contains": ["<h1>Página no encontrada</h1>"]
     },
     {
       "path": "/users",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -185,17 +185,22 @@ try {
   await build();
   await withServer('SSR', [], async (origin) => {
     for (const { path, status, contains = [], headers = {} } of routes) {
+      assert.ok(
+        headers && typeof headers === 'object' && !Array.isArray(headers),
+        `SSR GET ${path}: headers must be an object.`,
+      );
+      const label = `SSR GET ${path}${Object.keys(headers).length ? ` ${JSON.stringify(headers)}` : ''}`;
       const response = await inspect(origin, path, { headers });
 
-      assert.equal(response.status, status, `SSR GET ${path}: expected status ${status}.`);
+      assert.equal(response.status, status, `${label}: expected status ${status}.`);
       for (const marker of contains) {
         assert.ok(
           response.html.includes(marker),
-          `SSR GET ${path}: missing ${JSON.stringify(marker)}.`,
+          `${label}: missing ${JSON.stringify(marker)}.`,
         );
       }
 
-      console.info(`[smoke] SSR GET ${path}: ${status}; ${contains.length} content checks passed.`);
+      console.info(`[smoke] ${label}: ${status}; ${contains.length} content checks passed.`);
     }
 
     const first = routes[0];

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,18 +1,22 @@
 import { MetaManagerProvider } from '@lomray/react-head-manager';
 import type { Manager as MetaManager } from '@lomray/react-head-manager';
+import type { i18n } from 'i18next';
 import type { FC, PropsWithChildren } from 'react';
 import { StrictMode } from 'react';
+import { I18nextProvider } from 'react-i18next';
 import '@assets/styles/index.css';
 
 interface IApp {
-  client?: { metaManager: MetaManager };
+  client?: { metaManager: MetaManager; localization: i18n };
   server?: IApp['client'];
 }
 
 const App: FC<PropsWithChildren<IApp>> = ({ children, client, server }) => (
   <StrictMode>
     <MetaManagerProvider manager={(client?.metaManager ?? server?.metaManager)!}>
-      {children}
+      <I18nextProvider i18n={(client?.localization ?? server?.localization)!}>
+        {children}
+      </I18nextProvider>
     </MetaManagerProvider>
   </StrictMode>
 );

--- a/src/assets/locales/en/forms.json
+++ b/src/assets/locales/en/forms.json
@@ -1,0 +1,3 @@
+{
+  "firstName": "First name"
+}

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1,0 +1,39 @@
+{
+  "checkIt": "English version.",
+  "home": {
+    "heading": "Minimal SSR example",
+    "description": "A minimal React app with server rendering and route loaders.",
+    "intro": "React routes, server-rendered HTML, and the same app in your browser.",
+    "users": "Load users before rendering",
+    "profile": "Open a user profile",
+    "loaderError": "Try a loader that returns 404",
+    "about": "Load a page with its own stylesheet",
+    "redirect": "Follow a server-aware redirect",
+    "clientOnly": "Open a browser-only page",
+    "missing": "Try an unknown route"
+  },
+  "users": {
+    "heading": "Users",
+    "description": "Users loaded before the server sends the page.",
+    "intro": "The loader waits 300 ms, then returns this list as resolved data."
+  },
+  "about": {
+    "heading": "About this example",
+    "description": "A lazy route with its own CSS module, included in server-rendered HTML.",
+    "intro": "This page is a lazy route. Its stylesheet is included in the server-rendered document."
+  },
+  "notFound": {
+    "heading": "Page not found",
+    "description": "The requested page does not exist.",
+    "home": "Go home"
+  },
+  "layout": {
+    "navigation": "Main navigation",
+    "home": "Home",
+    "users": "Users",
+    "about": "About",
+    "clientOnly": "Client only",
+    "loading": "Loading page…",
+    "language": "Language"
+  }
+}

--- a/src/assets/locales/es/forms.json
+++ b/src/assets/locales/es/forms.json
@@ -1,0 +1,3 @@
+{
+  "firstName": "Nombre"
+}

--- a/src/assets/locales/es/translation.json
+++ b/src/assets/locales/es/translation.json
@@ -1,0 +1,39 @@
+{
+  "checkIt": "Versión española.",
+  "home": {
+    "heading": "Ejemplo mínimo de SSR",
+    "description": "Una aplicación React mínima con renderizado en el servidor y cargadores de rutas.",
+    "intro": "Rutas de React, HTML generado en el servidor y la misma aplicación en tu navegador.",
+    "users": "Cargar usuarios antes de renderizar",
+    "profile": "Abrir un perfil de usuario",
+    "loaderError": "Probar un cargador que devuelve 404",
+    "about": "Cargar una página con su propia hoja de estilos",
+    "redirect": "Seguir una redirección del servidor",
+    "clientOnly": "Abrir una página solo para el navegador",
+    "missing": "Probar una ruta desconocida"
+  },
+  "users": {
+    "heading": "Usuarios",
+    "description": "Usuarios cargados antes de que el servidor envíe la página.",
+    "intro": "El cargador espera 300 ms y devuelve esta lista como datos resueltos."
+  },
+  "about": {
+    "heading": "Acerca de este ejemplo",
+    "description": "Una ruta de carga diferida con su propio módulo CSS, incluido en el HTML del servidor.",
+    "intro": "Esta página es una ruta de carga diferida. Su hoja de estilos está incluida en el documento generado por el servidor."
+  },
+  "notFound": {
+    "heading": "Página no encontrada",
+    "description": "La página solicitada no existe.",
+    "home": "Volver al inicio"
+  },
+  "layout": {
+    "navigation": "Navegación principal",
+    "home": "Inicio",
+    "users": "Usuarios",
+    "about": "Acerca de",
+    "clientOnly": "Solo navegador",
+    "loading": "Cargando página…",
+    "language": "Idioma"
+  }
+}

--- a/src/assets/locales/namespaces.ts
+++ b/src/assets/locales/namespaces.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import-x/extensions -- JSON resources need explicit extensions for Vite. */
+import forms from './en/forms.json';
+import translation from './en/translation.json';
+import formsES from './es/forms.json';
+import translationES from './es/translation.json';
+
+export default {
+  en: { translation, forms },
+  es: { translation: translationES, forms: formsES },
+};

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,13 +1,25 @@
 import { Manager as MetaManager } from '@lomray/react-head-manager';
 import entryClient from '@lomray/vite-ssr-boost/browser/entry';
 import getServerState from '@lomray/vite-ssr-boost/helpers/get-server-state';
+import resources from '@assets/locales/namespaces';
 import StateKey from '@constants/state-key';
 import routes from '@routes/index';
+import type { ILocalizationState } from '@services/localization';
+import { detectLanguage, initLocalization } from '@services/localization';
 import App from './app';
 
 void entryClient(App, routes, {
-  init: () =>
-    Promise.resolve({
+  init: async ({ isSSRMode }) => {
+    const state = isSSRMode
+      ? getServerState<ILocalizationState>(StateKey.localization, import.meta.env.PROD)
+      : { language: detectLanguage(document.cookie, navigator.languages.join(',')) };
+    const localization = await initLocalization({ language: state.language, resources });
+
+    document.documentElement.lang = localization.language;
+
+    return {
       metaManager: new MetaManager(getServerState(StateKey.metaManager, import.meta.env.PROD)),
-    }),
+      localization,
+    };
+  },
 });

--- a/src/common/components/layouts/app/index.tsx
+++ b/src/common/components/layouts/app/index.tsx
@@ -1,19 +1,45 @@
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, Outlet, useNavigation } from 'react-router';
+import type { Language } from '@services/localization';
+
+const switchLanguage = (language: Language) => {
+  document.cookie = `lang=${language}; Path=/; Max-Age=31536000; SameSite=Lax`;
+  window.location.reload();
+};
 
 const AppLayout: FC = () => {
   const navigation = useNavigation();
+  const { t, i18n } = useTranslation();
 
   return (
     <>
       <header>
-        <nav aria-label="Main navigation">
-          <Link to="/">Home</Link>
-          <Link to="/users">Users</Link>
-          <Link to="/about">About</Link>
-          <Link to="/client-only">Client only</Link>
+        <nav aria-label={t('layout.navigation')}>
+          <Link to="/">{t('layout.home')}</Link>
+          <Link to="/users">{t('layout.users')}</Link>
+          <Link to="/about">{t('layout.about')}</Link>
+          <Link to="/client-only">{t('layout.clientOnly')}</Link>
         </nav>
-        <p role="status">{navigation.state !== 'idle' ? 'Loading page…' : null}</p>
+        <nav aria-label={t('layout.language')}>
+          <button
+            type="button"
+            lang="en"
+            aria-pressed={i18n.language === 'en'}
+            onClick={() => switchLanguage('en')}
+          >
+            English
+          </button>
+          <button
+            type="button"
+            lang="es"
+            aria-pressed={i18n.language === 'es'}
+            onClick={() => switchLanguage('es')}
+          >
+            Español
+          </button>
+        </nav>
+        <p role="status">{navigation.state !== 'idle' ? t('layout.loading') : null}</p>
       </header>
       <main>
         <Outlet />

--- a/src/common/services/localization.ts
+++ b/src/common/services/localization.ts
@@ -1,0 +1,68 @@
+import { createInstance } from 'i18next';
+import type { Resource } from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import resources from '@assets/locales/namespaces';
+
+type Language = keyof typeof resources;
+
+interface ILocalizationState {
+  language: string;
+  resources?: Resource;
+}
+
+const supportedLanguage = (value: string): Language | undefined => {
+  const [language] = value.trim().toLowerCase().split('-');
+
+  return language === 'en' || language === 'es' ? language : undefined;
+};
+
+/** Cookie first, then the first supported language in header order, then English. */
+const detectLanguage = (cookie = '', acceptLanguage = ''): Language => {
+  const value = cookie.split(';').find((part) => part.trim().startsWith('lang='));
+
+  if (value) {
+    try {
+      const language = supportedLanguage(decodeURIComponent(value.trim().slice(5)));
+
+      if (language) {
+        return language;
+      }
+    } catch {
+      // Ignore malformed cookie encoding and continue with Accept-Language.
+    }
+  }
+
+  for (const preference of acceptLanguage.split(',')) {
+    const [tag, ...parameters] = preference.split(';');
+    const isExcluded = parameters.some((parameter) => /^\s*q=0(?:\.0*)?\s*$/i.test(parameter));
+    const language = supportedLanguage(tag);
+
+    if (language && !isExcluded) {
+      return language;
+    }
+  }
+
+  return 'en';
+};
+
+/** Create an instance for this request or browser; never share mutable language state. */
+const initLocalization = async (state: ILocalizationState = { language: 'en' }) => {
+  const localization = createInstance();
+
+  await localization.use(initReactI18next).init({
+    lng: state.language,
+    resources: structuredClone(state.resources ?? resources),
+    fallbackLng: 'en',
+    supportedLngs: ['en', 'es'],
+    load: 'languageOnly',
+    ns: ['translation', 'forms'],
+    defaultNS: 'translation',
+    interpolation: { escapeValue: false },
+  });
+
+  return localization;
+};
+
+export { detectLanguage, initLocalization };
+
+export type { Language, ILocalizationState };

--- a/src/constants/state-key.ts
+++ b/src/constants/state-key.ts
@@ -1,5 +1,6 @@
 enum StateKey {
   metaManager = '_metaState_',
+  localization = '_localizationState_',
 }
 
 export default StateKey;

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,20 +1,22 @@
 import { Meta } from '@lomray/react-head-manager';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import styles from './styles.module.css';
 
 // eslint-disable-next-line import-x/prefer-default-export -- React Router lazy routes use this named export.
-export const Component: FC = () => (
-  <>
-    <Meta>
-      <title>About | Minimal SSR example</title>
-      <meta
-        name="description"
-        content="A lazy route with its own CSS module, included in server-rendered HTML."
-      />
-    </Meta>
-    <h1>About this example</h1>
-    <p className={styles.note}>
-      This page is a lazy route. Its stylesheet is included in the server-rendered document.
-    </p>
-  </>
-);
+export const Component: FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Meta>
+        <title>
+          {t('about.heading')} | {t('home.heading')}
+        </title>
+        <meta name="description" content={t('about.description')} />
+      </Meta>
+      <h1>{t('about.heading')}</h1>
+      <p className={styles.note}>{t('about.intro')}</p>
+    </>
+  );
+};

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,42 +1,46 @@
 import { Meta } from '@lomray/react-head-manager';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
-const Home: FC = () => (
-  <>
-    <Meta>
-      <title>Home | Minimal SSR example</title>
-      <meta
-        name="description"
-        content="A minimal React app with server rendering and route loaders."
-      />
-    </Meta>
-    <h1>Minimal SSR example</h1>
-    <p>React routes, server-rendered HTML, and the same app in your browser.</p>
-    <ul>
-      <li>
-        <Link to="/users">Load users before rendering</Link>
-      </li>
-      <li>
-        <Link to="/users/1">Open a user profile</Link>
-      </li>
-      <li>
-        <Link to="/users/999">Try a loader that returns 404</Link>
-      </li>
-      <li>
-        <Link to="/about">Load a page with its own stylesheet</Link>
-      </li>
-      <li>
-        <Link to="/redirect">Follow a server-aware redirect</Link>
-      </li>
-      <li>
-        <Link to="/client-only">Open a browser-only page</Link>
-      </li>
-      <li>
-        <Link to="/missing">Try an unknown route</Link>
-      </li>
-    </ul>
-  </>
-);
+const Home: FC = () => {
+  const { t } = useTranslation();
+  const heading = t('home.heading');
+
+  return (
+    <>
+      <Meta>
+        <title>{heading}</title>
+        <meta name="description" content={t('home.description')} />
+      </Meta>
+      <h1>{heading}</h1>
+      <p>{t('checkIt')}</p>
+      <p>{t('home.intro')}</p>
+      <ul>
+        <li>
+          <Link to="/users">{t('home.users')}</Link>
+        </li>
+        <li>
+          <Link to="/users/1">{t('home.profile')}</Link>
+        </li>
+        <li>
+          <Link to="/users/999">{t('home.loaderError')}</Link>
+        </li>
+        <li>
+          <Link to="/about">{t('home.about')}</Link>
+        </li>
+        <li>
+          <Link to="/redirect">{t('home.redirect')}</Link>
+        </li>
+        <li>
+          <Link to="/client-only">{t('home.clientOnly')}</Link>
+        </li>
+        <li>
+          <Link to="/missing">{t('home.missing')}</Link>
+        </li>
+      </ul>
+    </>
+  );
+};
 
 export default Home;

--- a/src/pages/not-found/index.tsx
+++ b/src/pages/not-found/index.tsx
@@ -1,18 +1,25 @@
 import { Meta } from '@lomray/react-head-manager';
 import ResponseStatus from '@lomray/vite-ssr-boost/components/response-status';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
-const NotFound: FC = () => (
-  <>
-    <Meta>
-      <title>Not found | Minimal SSR example</title>
-      <meta name="description" content="The requested page does not exist." />
-    </Meta>
-    <ResponseStatus status={404} />
-    <h1>Page not found</h1>
-    <Link to="/">Go home</Link>
-  </>
-);
+const NotFound: FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Meta>
+        <title>
+          {t('notFound.heading')} | {t('home.heading')}
+        </title>
+        <meta name="description" content={t('notFound.description')} />
+      </Meta>
+      <ResponseStatus status={404} />
+      <h1>{t('notFound.heading')}</h1>
+      <Link to="/">{t('notFound.home')}</Link>
+    </>
+  );
+};
 
 export default NotFound;

--- a/src/pages/users/index.tsx
+++ b/src/pages/users/index.tsx
@@ -1,5 +1,6 @@
 import { Meta } from '@lomray/react-head-manager';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useLoaderData } from 'react-router';
 import users from '@data/users';
 
@@ -12,16 +13,19 @@ export const loader = async () => {
 };
 
 const Users: FC = () => {
+  const { t } = useTranslation();
   const data = useLoaderData<typeof loader>();
 
   return (
     <>
       <Meta>
-        <title>Users | Minimal SSR example</title>
-        <meta name="description" content="Users loaded before the server sends the page." />
+        <title>
+          {t('users.heading')} | {t('home.heading')}
+        </title>
+        <meta name="description" content={t('users.description')} />
       </Meta>
-      <h1>Users</h1>
-      <p>The loader waits 300 ms, then returns this list as resolved data.</p>
+      <h1>{t('users.heading')}</h1>
+      <p>{t('users.intro')}</p>
       <ul>
         {data.map((user) => (
           <li key={user.id}>

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,24 +1,41 @@
+import type { IncomingMessage } from 'node:http';
 import { Manager as MetaManager } from '@lomray/react-head-manager';
 import MetaServer from '@lomray/react-head-manager/server';
 import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
 import { isbot } from 'isbot';
+import resources from '@assets/locales/namespaces';
 import StateKey from '@constants/state-key';
 import routes from '@routes/index';
+import { detectLanguage, initLocalization } from '@services/localization';
 import App from './app';
 
 export default entryServer(App, routes, {
   init: () => ({
-    onRequest: () => ({ appProps: { metaManager: new MetaManager() } }),
+    onRequest: async (req: IncomingMessage) => ({
+      appProps: {
+        metaManager: new MetaManager(),
+        localization: await initLocalization({
+          language: detectLanguage(req.headers.cookie, req.headers['accept-language']),
+          resources,
+        }),
+      },
+    }),
     onRouterReady: ({ context: { request } }) => ({
       isStream:
         !isbot(request.headers.get('user-agent') ?? '') &&
         !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
     }),
     onShellReady: ({ context: { appProps, html } }) => ({
-      header: MetaServer.inject(html.header, appProps.metaManager),
+      header: MetaServer.inject(
+        html.header.replace('<html lang="en">', `<html lang="${appProps.localization.language}">`),
+        appProps.metaManager,
+      ),
     }),
     getState: ({ context: { appProps } }) => ({
       [StateKey.metaManager]: MetaServer.getState(appProps.metaManager),
+      [StateKey.localization]: {
+        language: appProps.localization.language,
+      },
     }),
   }),
 });

--- a/types/i18next.d.ts
+++ b/types/i18next.d.ts
@@ -1,0 +1,9 @@
+import 'i18next';
+import type namespaces from '../src/assets/locales/namespaces';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'translation';
+    resources: (typeof namespaces)['en'];
+  }
+}


### PR DESCRIPTION
## Goal

`example/localization`: i18next on top of `example/minimal`, with the language chosen on the server and carried to the client before hydration.

## What the branch contains

- Two runtime dependencies on top of the minimal six: `i18next` and `react-i18next`. No HTTP backend and no browser detector: the resources are bundled (`src/assets/locales/{en,es}/*.json` through `src/assets/locales/namespaces.ts`) and the server picks the language.
- `src/common/services/localization.ts`: `detectLanguage` (the `lang` cookie first, then the first supported entry of `Accept-Language`, then `en`; regional tags fold to the base language, `q=0` entries are skipped) and `initLocalization`, which creates a request-local i18next instance.
- `src/server.ts`: `onRequest` initializes the instance for the request, `onShellReady` sets `<html lang>`, `getState` transfers `{ language }` only; `onRouterReady` reads headers through `context.request`.
- `src/client.ts`: boots the same language from the transferred state and the bundled resources before hydration (SPA builds detect from the cookie and `navigator.languages`).
- Layout: English / Español buttons that set the cookie and reload; `types/i18next.d.ts` types the translation keys.
- Smoke config covers `/` in English, `/` with `Accept-Language: es`, cookie precedence over the header, `/about`, `/users` and the 404 page in Spanish, plus the minimal routes.
- README: language selection, resources and typing, state transfer and why server and client must agree before hydration, the switcher, commands, the "Need more?" table.

## Verification

- Acceptance script: dependency set, lint (`--max-warnings=0`, `eslint .`), ts, style, `build --throw-warnings` with zero warnings, `npm run smoke`, curl matrix (`<html lang>` and headings for `en`, `Accept-Language: es`, cookie `lang=es` over `Accept-Language: en`, `/about` styles in Spanish, HEAD with empty body, crawler cookie, 404 and 301), development server with `Accept-Language: es`: all pass. The Spanish response contains no English resource text; the transferred state is 17 bytes of JSON.
- Browser (Chrome): Spanish page hydrates without console output, the switcher changes the language and `<html lang>`, client-side navigation keeps the language.

## Follow-ups

- `prod` chore: add `example/custom-server` and `example/localization` to Renovate `baseBranches` and link both README rows; delete the old `feature/localization` branch.
