### PR TITLE
chore: track the custom-server and localization examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 | --- | --- | --- | --- |
 | `prod` | Streaming SSR, MobX, consistent Suspense, meta tags and route management | Use the full reference app | [Browse](https://github.com/Lomray-Software/vite-template/tree/prod) |
 | `example/minimal` | Six runtime dependencies, loaders, a lazy route with CSS, redirect, client-only route and 404, plus the SPA-to-SSR file diff | Start with a small SSR app | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/minimal) |
-| `example/custom-server` (planned) | A custom Fastify server | Own the production server once available | Planned |
-| `example/localization` (planned) | Localization with server and client language state | Add localization once available | Planned |
+| `example/custom-server` | Development through the managed CLI, production through an application-owned Fastify server with static assets, compression and Early Hints; dual export of the managed entry and a Fetch handler | Own the production server | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/custom-server) |
+| `example/localization` | i18next with the language chosen on the server from the cookie or Accept-Language, transferred to the client before hydration, and a cookie-based switcher | Add localization | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/localization) |
 
 ## Demo links
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "baseBranches": ["prod", "example/minimal"],
+  "baseBranches": ["prod", "example/minimal", "example/custom-server", "example/localization"],
   "rangeStrategy": "bump",
   "automerge": false,
   "labels": ["dependencies"],


### PR DESCRIPTION
Renovate keeps all three example branches current; the README branch table links the merged custom-server and localization examples.