### PR TITLE
fix: flush the suspense stream at response end and update companion libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "@lomray/vite-template",
       "version": "1.0.0",
       "dependencies": {
-        "@lomray/consistent-suspense": "^2.0.8",
-        "@lomray/react-head-manager": "^2.1.1",
+        "@lomray/consistent-suspense": "^2.0.9",
+        "@lomray/react-head-manager": "^2.1.2",
         "@lomray/react-mobx-manager": "^4.5.0",
         "@lomray/react-route-manager": "^2.0.0",
-        "@lomray/vite-ssr-boost": "^8.0.0-beta.2",
+        "@lomray/vite-ssr-boost": "^8.0.0-beta.6",
         "axios": "^1.20.0",
         "classnames": "^2.5.1",
         "cookie-parser": "^1.4.7",
@@ -1147,12 +1147,13 @@
       "license": "MIT"
     },
     "node_modules/@lomray/consistent-suspense": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@lomray/consistent-suspense/-/consistent-suspense-2.0.8.tgz",
-      "integrity": "sha512-GLdLviT72iYCFd+Dh+v5AWuzVZZoZ5PerTQx1mRS+US7vS33GB3Ouf93z/uSsOsxeTG9RGmbtw/hPX4BRdhz3Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@lomray/consistent-suspense/-/consistent-suspense-2.0.9.tgz",
+      "integrity": "sha512-3rNQJIVoqrFs0Vj8uNeGBLsES3YopdDeP/z199v3Qhh/gqnLSNkvAzVV6YpUc7rZMnuJXU02jurfAK1UL4FJ0w==",
       "license": "MIT",
       "peerDependencies": {
-        "react": ">=17.0.2"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@lomray/eslint-config": {
@@ -1204,9 +1205,9 @@
       }
     },
     "node_modules/@lomray/event-manager": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@lomray/event-manager/-/event-manager-2.0.2.tgz",
-      "integrity": "sha512-hJXuBH9rlI8m/AznnZe178MxmmqhgZPNQPgvXeJ7HXziJvq0WBYsHGepL2VRuIxZ4J1LrBr+Hc+z4EK+tRQFGA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@lomray/event-manager/-/event-manager-2.0.3.tgz",
+      "integrity": "sha512-RX4LXpx/wQGxL/4v2FFODGWqF/6tm7o7+j6s17IqiuaVBbeWhiry63aSgKAozrk+Q6xlbtE0a7pEruTsO+7GmQ==",
       "license": "MIT",
       "peer": true
     },
@@ -1224,9 +1225,9 @@
       }
     },
     "node_modules/@lomray/react-head-manager": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@lomray/react-head-manager/-/react-head-manager-2.1.1.tgz",
-      "integrity": "sha512-S2tNcBlE+Mi17JTJb1UZaWC1gUJa251cdnJwZP0JbMhZsnqpDclEHzgyKwF5qPqrSR25fvjZO5Z/+DC5z0gc5w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lomray/react-head-manager/-/react-head-manager-2.1.2.tgz",
+      "integrity": "sha512-iLvcekfL9zcZSBiwvx5CDm9QDYXicxpiul0SIHUZZKtuGdLj6xqmq9MjZ9GlnVs2wHIbHHdgxmaYg7tiTbtetg==",
       "license": "MIT",
       "dependencies": {
         "html-react-parser": "^5.1.15"
@@ -1254,9 +1255,9 @@
       }
     },
     "node_modules/@lomray/react-route-manager": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lomray/react-route-manager/-/react-route-manager-2.0.0.tgz",
-      "integrity": "sha512-Y4CKENftLYZVSSM5dKe2QR8Fw9rWDEoL0w7RG3mLM7ekfJW/ccs+a01YHQJhtTJabGi1HlwC8RAwhLFikKLXUw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lomray/react-route-manager/-/react-route-manager-2.0.1.tgz",
+      "integrity": "sha512-SsB/Zm133g8HsKhnKdsvqqDUfUY69sDzoJ2u1fEFms/uR1Zr3FkG0Aczuylcea23p47bsdmMiwBCATF7ObzFpQ==",
       "license": "MIT",
       "peerDependencies": {
         "react-router": ">=6.12.1"
@@ -1281,9 +1282,9 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0-beta.2.tgz",
-      "integrity": "sha512-bVLNxa0DUhxXZmpVloDG4Dhh60YPEAHlh9Gb7non5r055jNy9RdpUMqerzt8QJTU21OjcgS1twlt1ZBFdBlhmQ==",
+      "version": "8.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0-beta.6.tgz",
+      "integrity": "sha512-7P3kwuDcAn1mQRwP3Cvh2oqRfzBHp67iWYz0JY0HEW9K/BaAFUyczcM2hDclRannWnzXxVjYbgb6xgOsx+LFtQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@lomray/consistent-suspense": "^2.0.8",
-    "@lomray/react-head-manager": "^2.1.1",
+    "@lomray/consistent-suspense": "^2.0.9",
+    "@lomray/react-head-manager": "^2.1.2",
     "@lomray/react-mobx-manager": "^4.5.0",
     "@lomray/react-route-manager": "^2.0.0",
-    "@lomray/vite-ssr-boost": "^8.0.0-beta.2",
+    "@lomray/vite-ssr-boost": "^8.0.0-beta.6",
     "axios": "^1.20.0",
     "classnames": "^2.5.1",
     "cookie-parser": "^1.4.7",

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,6 @@ import CookieParser from 'cookie-parser';
 import { createIsbotFromList, list, isbotPatterns } from 'isbot';
 import { enableStaticRendering } from 'mobx-react-lite';
 import StateKey from '@constants/state-key';
-import type { ICookies } from '@interfaces/cookies';
 import routes from '@routes/index';
 import App from './app';
 
@@ -65,9 +64,12 @@ export default entryServer(App, routes, {
     /**
      * We can control stream mode here
      */
-    onRouterReady: ({ context: { req } }) => {
-      const isStream =
-        !isBot(req.get('user-agent') || '') && (req.cookies as ICookies)?.isCrawler !== '1';
+    onRouterReady: ({ context: { request } }) => {
+      const isCrawler = request.headers
+        .get('cookie')
+        ?.split(';')
+        .some((cookie) => cookie.trim() === 'isCrawler=1');
+      const isStream = !isBot(request.headers.get('user-agent') || '') && !isCrawler;
 
       return {
         isStream,
@@ -97,12 +99,13 @@ export default entryServer(App, routes, {
         isStream,
       },
       html,
+      isEnd,
     }) => {
       if (!isStream) {
         return;
       }
 
-      return streamSuspense.analyze(html);
+      return isEnd ? streamSuspense.end() : streamSuspense.analyze(html);
     },
     /**
      * Return server state to client (once when app she'll ready) for:


### PR DESCRIPTION
## Goal

Adopt the corrected streaming contract of vite-ssr-boost 8.0.0-beta.6 and pick up the companion library fixes found in today's audits.

## Changes

- `src/server.ts`: `onResponse` returns `streamSuspense.end()` on the final `isEnd` call and `streamSuspense.analyze(html)` otherwise, matching consistent-suspense 2.0.9 (incremental parser: unfinished tokens are withheld, every completed boundary gets its state before its reveal instruction, the tail is flushed at the end). `onRouterReady` reads the user agent and the `isCrawler` cookie through the portable `context.request` instead of the Express `req`.
- Dependencies: `@lomray/vite-ssr-boost` `^8.0.0-beta.6` (empty-transform and end-of-stream contract, Fetch request on managed hooks, hydration waits for the serialized state, routes parser accepts `satisfies`), `@lomray/consistent-suspense` `^2.0.9` (stable IDs after a server-side suspend, incremental stream parsing, exports map, class error boundaries), `@lomray/react-head-manager` `^2.1.2` (single `<head>` on React 19); the lockfile also resolves `@lomray/event-manager` 2.0.3 (dispatch snapshot, channel cleanup, accurate declarations) and `@lomray/react-route-manager` 2.0.1 (path joining, static URLs, typing, Node 22 build).

## Verification

- Acceptance script: lockfile versions, `isEnd`/`context.request` in the server entry, template anchors, clean `npm ci`, lint, ts, style, `build --throw-warnings` with zero warnings, SSR curl checks (hydration data, 404, HEAD with empty body, crawler cookie, 301, styles), SPA build and start, and the library's own template acceptance (`scripts/test-template.mjs` at staging 3f87a91) in both dependency modes including the development cold-start gate.
- Streamed pages: `/details` (2 boundaries) and `/nested-suspense` (6) emit one state script per `data-suspense-id` marker, each before its `$RC` instruction; a single `<head>`; the 15 anchor `href`s on `/` and `/details` are unchanged.
- Browser (Chrome) through a proxy that delays every HTML chunk after the module script by 400 ms with a cached bundle: `/`, `/details` and `/nested-suspense` hydrate without console output and without duplicated content.
