### PR TITLE
chore: use vite-ssr-boost 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minimal SSR example
 
-This is the `example/minimal` branch of vite-template, using React 19, React Router 8, Vite 8, and vite-ssr-boost 8 beta.
+This is the `example/minimal` branch of vite-template, using React 19, React Router 8, Vite 8, and vite-ssr-boost 8.0.0.
 The app uses React Router [Data mode](https://reactrouter.com/start/modes#data).
 
 - Server-rendered pages with a title and description from a request-scoped meta manager.
@@ -14,7 +14,7 @@ The app uses React Router [Data mode](https://reactrouter.com/start/modes#data).
 Use Node 22.23.2 (`.nvmrc`) and npm.
 The six direct runtime dependencies and their versions are listed in [package.json](package.json).
 They are `react`, `react-dom`, `react-router`, `@lomray/vite-ssr-boost`, `@lomray/react-head-manager`, and `isbot`.
-Keep vite-ssr-boost on the `^8.0.0-beta.5` range while using this example.
+Keep vite-ssr-boost on the `^8.0.0` range while using this example.
 The head manager also installs `@lomray/consistent-suspense` as a transitive peer dependency; application code does not import it.
 
 This comparison starts with Data-mode route objects, a shared `App` wrapper, and metadata already in the SPA.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@lomray/react-head-manager": "^2.1.1",
-        "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+        "@lomray/vite-ssr-boost": "^8.0.0",
         "isbot": "^5.2.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0-beta.5.tgz",
-      "integrity": "sha512-6sTX9xTemJgxM/1GnvtR37eQ4tY2qAqtu7tJ95ItRgX3iXqx9kz/vkpj3puCUnWMzNZzP75muD4uHrXMCDYvcg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0.tgz",
+      "integrity": "sha512-cZuy1ag+fJmZqn2GNb8+lvnxH3Ag1+6hhTGz8jTkmcve6SE2l2aoBKREh8svSGQdDr3v/A6wkM8G5fZoOBs+Vg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@lomray/react-head-manager": "^2.1.1",
-    "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+    "@lomray/vite-ssr-boost": "^8.0.0",
     "isbot": "^5.2.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",


### PR DESCRIPTION
Moves the example to the released vite-ssr-boost 8.0.0 (^8.0.0) and drops the beta wording from the README. Verified: clean npm ci, lint, ts, style, build --throw-warnings with zero warnings, npm run smoke.