### PR TITLE
chore: use vite-ssr-boost 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the `example/custom-server` branch of vite-template.
 It extends [example/minimal](https://github.com/Lomray-Software/vite-template/tree/example/minimal) with a production server owned by the application.
-It uses React 19, React Router 8 [Data mode](https://reactrouter.com/start/modes#data), Vite 8, and vite-ssr-boost 8 beta.
+It uses React 19, React Router 8 [Data mode](https://reactrouter.com/start/modes#data), Vite 8, and vite-ssr-boost 8.0.0.
 
 - A named Fetch handler and a default managed CLI entry share the same app, routes, and metadata hooks.
 - Development uses the managed CLI and its Vite integration.
@@ -19,7 +19,7 @@ Loaders return resolved first-paint data. Nested loader promises serialize as `{
 Use Node 22.23.2 (`.nvmrc`) and run `npm ci` from the repository root.
 [package.json](package.json) has eight direct runtime dependencies: the six from the minimal example plus `fastify` and `@fastify/static`.
 Fastify runs the HTTP server; its static plugin serves the browser build.
-The library range is `^8.0.0-beta.5`.
+The library range is `^8.0.0`.
 
 These commands use the scripts in [package.json](package.json):
 
@@ -173,14 +173,14 @@ Omitting `servers` preserves the managed SSR and SPA behavior used by other bran
 
 ## Known limitations
 
-The spike uses `@lomray/vite-ssr-boost@8.0.0-beta.5`. No library files were changed.
+The spike uses `@lomray/vite-ssr-boost@8.0.0`. No library files were changed.
 
 - Route assets require the deep imports `@lomray/vite-ssr-boost/services/server-config` and `@lomray/vite-ssr-boost/services/ssr-manifest`. `ServerConfig.init({ isProd: true, isOnlyClient: false })` and `SsrManifest.get(config).injectAssets(context)` work from plain `server/index.mjs`. Injection adds the lazy `/about` stylesheet and returns `Link` headers, forwarded through `executionContext.onEarlyHints`. No manual manifest parsing or tag generation was needed.
 - These services couple the launcher to managed-server configuration. Build discovery uses the working directory, so start this example from the repository root. `SsrManifest.get` is a process-wide singleton that retains the first configuration; this example serves one build per process. Proposed public helper: `createRouteAssetPreparer<TAppProps>(options: { buildDir: string; modulePreload?: boolean }): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']>`, exported from `@lomray/vite-ssr-boost/node/production`. It would load an independent manifest for the explicit build directory, inject matched route assets, and forward Early Hints without importing `services/*`.
 - HTML bootstrap is manual. The launcher reads `build/client/index.html` once, validates exactly one `<!--ssr-outlet-->`, and supplies a fresh `{ header, footer }` object for every request. The example's `configureHandler` installs `getHtml` and `prepare` before listening; it is application glue, not a library API. Proposed public helper: `loadHtmlShell(options: { indexFile: string; outlet?: string }): Promise<() => IHtmlShell>`, also exported from `@lomray/vite-ssr-boost/node/production`. It would perform that read, validation, split, and per-request copy.
 - Fastify owns static-file caching, listening, and shutdown. Its adapter owns streamed response compression. Development and HMR still use the managed CLI. Rebuild and restart production after changing the app or its assets.
 
-The proposed signatures describe missing public helpers. They are not implemented or importable in this beta.
+The proposed signatures describe missing public helpers. They are not implemented or importable in 8.0.0.
 
 ## Need more?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fastify/static": "^10.1.3",
         "@lomray/react-head-manager": "^2.1.1",
-        "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+        "@lomray/vite-ssr-boost": "^8.0.0",
         "fastify": "^5.12.3",
         "isbot": "^5.2.2",
         "react": "^19.2.8",
@@ -1471,9 +1471,9 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0-beta.5.tgz",
-      "integrity": "sha512-6sTX9xTemJgxM/1GnvtR37eQ4tY2qAqtu7tJ95ItRgX3iXqx9kz/vkpj3puCUnWMzNZzP75muD4uHrXMCDYvcg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0.tgz",
+      "integrity": "sha512-cZuy1ag+fJmZqn2GNb8+lvnxH3Ag1+6hhTGz8jTkmcve6SE2l2aoBKREh8svSGQdDr3v/A6wkM8G5fZoOBs+Vg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@fastify/static": "^10.1.3",
     "@lomray/react-head-manager": "^2.1.1",
-    "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+    "@lomray/vite-ssr-boost": "^8.0.0",
     "fastify": "^5.12.3",
     "isbot": "^5.2.2",
     "react": "^19.2.8",


### PR DESCRIPTION
Moves the example to the released vite-ssr-boost 8.0.0 (^8.0.0) and drops the beta wording from the README. Verified: clean npm ci, lint, ts, style, build --throw-warnings with zero warnings, npm run smoke.