### PR TITLE
chore: use vite-ssr-boost 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@lomray/react-head-manager": "^2.1.1",
-        "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+        "@lomray/vite-ssr-boost": "^8.0.0",
         "i18next": "^26.4.2",
         "isbot": "^5.2.2",
         "react": "^19.2.8",
@@ -1255,9 +1255,9 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0-beta.5.tgz",
-      "integrity": "sha512-6sTX9xTemJgxM/1GnvtR37eQ4tY2qAqtu7tJ95ItRgX3iXqx9kz/vkpj3puCUnWMzNZzP75muD4uHrXMCDYvcg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0.tgz",
+      "integrity": "sha512-cZuy1ag+fJmZqn2GNb8+lvnxH3Ag1+6hhTGz8jTkmcve6SE2l2aoBKREh8svSGQdDr3v/A6wkM8G5fZoOBs+Vg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@lomray/react-head-manager": "^2.1.1",
-    "@lomray/vite-ssr-boost": "^8.0.0-beta.5",
+    "@lomray/vite-ssr-boost": "^8.0.0",
     "i18next": "^26.4.2",
     "isbot": "^5.2.2",
     "react": "^19.2.8",


### PR DESCRIPTION
Moves the example to the released vite-ssr-boost 8.0.0 (^8.0.0) and drops the beta wording from the README. Verified: clean npm ci, lint, ts, style, build --throw-warnings with zero warnings, npm run smoke.