### PR TITLE
chore: use vite-ssr-boost 8.0.0 and react-mobx-manager 4.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@lomray/consistent-suspense": "^2.0.9",
         "@lomray/react-head-manager": "^2.1.2",
-        "@lomray/react-mobx-manager": "^4.5.0",
+        "@lomray/react-mobx-manager": "^4.5.1",
         "@lomray/react-route-manager": "^2.0.0",
-        "@lomray/vite-ssr-boost": "^8.0.0-beta.6",
+        "@lomray/vite-ssr-boost": "^8.0.0",
         "axios": "^1.20.0",
         "classnames": "^2.5.1",
         "cookie-parser": "^1.4.7",
@@ -1240,15 +1240,15 @@
       }
     },
     "node_modules/@lomray/react-mobx-manager": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@lomray/react-mobx-manager/-/react-mobx-manager-4.5.0.tgz",
-      "integrity": "sha512-FcdBkw0r5zp9vbDOqBTc8WP8omVv+AQ4acLfqhd2ZY+2HXOQmI6W0kvt7asdT5FztK6c9XckSbH2W5ORh8EWkQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@lomray/react-mobx-manager/-/react-mobx-manager-4.5.1.tgz",
+      "integrity": "sha512-Rehn9LVAiiTYcBBI1bAk7RiQVmykDo+3R0INnEIQz9n+GgyGywvyC4N1nmWooqgpb0N68aceI2MyKA3MeQq9eQ==",
       "license": "MIT",
       "peerDependencies": {
         "@lomray/consistent-suspense": ">=2.0.1",
         "@lomray/event-manager": ">=2.0.2",
         "hoist-non-react-statics": ">=3.3.2",
-        "lodash": ">=4.17.21",
+        "lodash": ">=4.18.1",
         "mobx": ">=6.9.0",
         "mobx-react-lite": "^3 || ^4 || ^5",
         "react": "^19 || ^18 || ^17"
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0-beta.6.tgz",
-      "integrity": "sha512-7P3kwuDcAn1mQRwP3Cvh2oqRfzBHp67iWYz0JY0HEW9K/BaAFUyczcM2hDclRannWnzXxVjYbgb6xgOsx+LFtQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.0.0.tgz",
+      "integrity": "sha512-cZuy1ag+fJmZqn2GNb8+lvnxH3Ag1+6hhTGz8jTkmcve6SE2l2aoBKREh8svSGQdDr3v/A6wkM8G5fZoOBs+Vg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "@lomray/consistent-suspense": "^2.0.9",
     "@lomray/react-head-manager": "^2.1.2",
-    "@lomray/react-mobx-manager": "^4.5.0",
+    "@lomray/react-mobx-manager": "^4.5.1",
     "@lomray/react-route-manager": "^2.0.0",
-    "@lomray/vite-ssr-boost": "^8.0.0-beta.6",
+    "@lomray/vite-ssr-boost": "^8.0.0",
     "axios": "^1.20.0",
     "classnames": "^2.5.1",
     "cookie-parser": "^1.4.7",


### PR DESCRIPTION
Moves prod to the released vite-ssr-boost 8.0.0 (^8.0.0) and react-mobx-manager 4.5.1 (^4.5.1). Verified: clean npm ci, lint, ts, style, build --throw-warnings with zero warnings, SSR and SPA curl checks, the library's template acceptance in both dependency modes, and one state script per streamed boundary on /details (2) and /nested-suspense (6).