### PR TITLE
chore: update dependencies and add the size budget check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -42,5 +42,8 @@ jobs:
       - name: Build check
         run: npm run build -- --throw-warnings
 
+      - name: Client size budget
+        run: npm run size:check
+
       - name: Smoke check
         run: npm run smoke

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fastify/static": "^10.1.3",
-        "@lomray/react-head-manager": "^2.1.1",
+        "@lomray/react-head-manager": "^2.1.2",
         "@lomray/vite-ssr-boost": "^8.1.0",
         "fastify": "^5.12.3",
         "isbot": "^5.2.2",
@@ -31,7 +31,7 @@
         "eslint": "^10.10.0",
         "globals": "^17.12.0",
         "husky": "^9.1.7",
-        "lint-staged": "^17.4.1",
+        "lint-staged": "^17.5.0",
         "prettier": "^3.9.6",
         "semantic-release": "^25.0.9",
         "stylelint": "^17.15.0",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "style:check": "stylelint \"src/**/*.{css,scss}\"",
     "style:format": "stylelint --fix \"src/**/*.{css,scss}\"",
     "ts:check": "tsc --project ./tsconfig.json --skipLibCheck --noemit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "size:check": "node scripts/size-budget.mjs"
   },
   "dependencies": {
     "@fastify/static": "^10.1.3",
-    "@lomray/react-head-manager": "^2.1.1",
+    "@lomray/react-head-manager": "^2.1.2",
     "@lomray/vite-ssr-boost": "^8.1.0",
     "fastify": "^5.12.3",
     "isbot": "^5.2.2",
@@ -42,7 +43,7 @@
     "eslint": "^10.10.0",
     "globals": "^17.12.0",
     "husky": "^9.1.7",
-    "lint-staged": "^17.4.1",
+    "lint-staged": "^17.5.0",
     "prettier": "^3.9.6",
     "semantic-release": "^25.0.9",
     "stylelint": "^17.15.0",

--- a/scripts/size-budget.mjs
+++ b/scripts/size-budget.mjs
@@ -1,0 +1,46 @@
+import { appendFile, readFile, readdir } from 'node:fs/promises';
+import { gzipSync } from 'node:zlib';
+
+// After an intentional size change, rebuild and set ceil(total gzip bytes * 1.05 / 1024).
+const SIZE_BUDGET_GZIP_KB = 109;
+
+const assets = new URL('../build/client/assets/', import.meta.url);
+const files = (await readdir(assets)).filter((file) => file.endsWith('.js')).sort();
+
+if (files.length === 0) {
+  throw new Error('No client JavaScript assets found. Run npm run build first.');
+}
+
+let totalGzip = 0;
+const rows = [];
+
+for (const file of files) {
+  const content = await readFile(new URL(file, assets));
+  const gzipBytes = gzipSync(content).length;
+
+  totalGzip += gzipBytes;
+  rows.push(`| ${file} | ${content.length} | ${gzipBytes} |`);
+}
+
+const summary = [
+  '### Client JavaScript size',
+  '',
+  '| File | Raw bytes | Gzip bytes |',
+  '| --- | ---: | ---: |',
+  ...rows,
+  '',
+  `Total gzip: **${totalGzip} bytes (${(totalGzip / 1024).toFixed(2)} KB)**.`,
+  `Budget: **${SIZE_BUDGET_GZIP_KB} KB (${SIZE_BUDGET_GZIP_KB * 1024} bytes)**; 1 KB = 1024 bytes.`,
+  '',
+].join('\n');
+
+console.log(summary);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+}
+
+if (totalGzip > SIZE_BUDGET_GZIP_KB * 1024) {
+  console.error('Client JavaScript exceeds the gzip size budget.');
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Goal

Same dependency policy as `prod` and a client size budget for this branch.

## Changes

- `@lomray/vite-ssr-boost` `^8.1.0` (lock 8.1.0), `@lomray/react-head-manager` `^2.1.2`, `lint-staged` 17.5.0; TypeScript stays on 6.0.3 (7.0.2 is not supported by `typescript-eslint`), `@types/node` stays on 22 (CI runs Node 22).
- `scripts/size-budget.mjs` + `npm run size:check` with the branch's own budget (measured gzip total + 5 percent), run after the build in this branch's `pr-check.yml`.

## Verification

`npm ci`, `npm run lint:check`, `npm run ts:check`, `npm run style:check`, `npm run build -- --throw-warnings`, `npm run size:check`, `npm run smoke`, `npm audit` (0 vulnerabilities): all green.
