### PR TITLE
fix: lighthouse findings on contrast, layout shift and robots in the audit build

### DIFF
--- a/.github/workflows/example-check.yml
+++ b/.github/workflows/example-check.yml
@@ -126,7 +126,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Build
-        run: npm run build -- --throw-warnings
+        run: npm run build -- --throw-warnings --unlock-robots
 
       - name: Run Lighthouse
         env:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ PR and example checks run `npm run size:check` after building; the script lists 
 After an intentional bundle change, rebuild and set that branch's budget to the measured gzip total plus 5%, rounded up to a whole KB.
 
 The example workflow also runs Lighthouse weekly and on manual dispatch for `/` and `/details` on `prod`, and `/` and `/about` on `example/minimal`.
+The audit build unlocks robots with `--unlock-robots`, matching the production deploy.
 It measures each URL three times, requires performance of at least 90, warns below 90 for accessibility, best practices and SEO, and publishes reports and median category scores in the workflow artifacts and summary.
 To run the prod checks locally, build the app, run `npm run start:ssr -- --port 4173`, then in another terminal run `npx --yes @lhci/cli@0.15.1 autorun --upload.target=temporary-public-storage` and `node scripts/lighthouse-summary.mjs`.
 Lighthouse reports are uploaded to temporary public storage.

--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -22,13 +22,13 @@
 }
 
 a {
-  color: #646cff;
+  color: #8b91ff;
   font-weight: 500;
   text-decoration: inherit;
 }
 
 a:hover {
-  color: #535bf2;
+  color: #a0a5ff;
 }
 
 body {
@@ -74,8 +74,11 @@ button:focus-visible {
     background-color: #ffffff;
     color: #213547;
   }
+  a {
+    color: #535bf2;
+  }
   a:hover {
-    color: #747bff;
+    color: #4149d9;
   }
   button {
     background-color: #f9f9f9;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -52,14 +52,22 @@ const Home: FCRoute = () => {
       </div>
       <div className={styles.logos}>
         <a href="https://vitejs.dev/" target="_blank" rel="nofollow">
-          <img src="/vite.svg" className={styles.logo} alt="Vite logo" />
+          <img src="/vite.svg" width={256} height={257} className={styles.logo} alt="Vite logo" />
         </a>
         <a href="https://react.dev" target="_blank" rel="nofollow">
-          <img src={ReactLogoImg} className={styles.logo} alt="React logo" />
+          <img
+            src={ReactLogoImg}
+            width={256}
+            height={228}
+            className={styles.logo}
+            alt="React logo"
+          />
         </a>
         <a href="https://github.com/Lomray-Software/vite-ssr-boost" target="_blank">
           <img
             src="https://raw.githubusercontent.com/Lomray-Software/vite-ssr-boost/prod/logo.png"
+            width={150}
+            height={150}
             className={cn(styles.logo, styles.logoBoost)}
             alt="SSR Boost logo"
           />
@@ -67,6 +75,8 @@ const Home: FCRoute = () => {
         <a href="https://github.com/Lomray-Software/react-mobx-manager" target="_blank">
           <img
             src="https://raw.githubusercontent.com/Lomray-Software/react-mobx-manager/prod/logo.png"
+            width={150}
+            height={150}
             className={cn(styles.logo, styles.logoBoost)}
             alt="Mobx Store Manager logo"
           />

--- a/src/pages/home/styles.module.scss
+++ b/src/pages/home/styles.module.scss
@@ -8,6 +8,7 @@
   height: 6em;
   padding: 1.5em;
   transition: filter 300ms;
+  width: auto;
   will-change: filter;
 
   &:hover {
@@ -25,5 +26,11 @@
 }
 
 .navigateExplain {
-  color: #888;
+  color: #8c8c8c;
+}
+
+@media (prefers-color-scheme: light) {
+  .navigateExplain {
+    color: #727272;
+  }
 }


### PR DESCRIPTION
## Goal

Act on the first weekly Lighthouse run (run 33986974930 dispatch): SEO 63–66 because the audit build ships `Disallow: /`, accessibility 89–92 because of link contrast, and CLS 0.107 on the home page.

## Changes

- The Lighthouse job builds with `--unlock-robots`, the same flag the production deploy passes (`app-build-args` in `release.yml`), so the audit sees `Allow: /` like the live site; `public/robots.txt` keeps `Disallow: /` for non-production builds. README sentence added.
- Link colors with WCAG AA contrast in both schemes: dark `#8b91ff` / hover `#a0a5ff` on `#242424` (5.61:1 / 6.89:1), light `#535bf2` / hover `#4149d9` on `#ffffff` (5.06:1 / 6.60:1); helper text `.navigateExplain` `#8c8c8c` dark (4.62:1) and `#727272` light (4.81:1). Buttons unchanged (17.4:1 / 19.95:1).
- CLS root cause: the React logo `<img>` had a CSS height but no reserved width ("Media element lacking an explicit size"). All four home logos now carry `width`/`height` attributes matching their intrinsic size, with `width: auto` in CSS to keep the 6em height.

## Verification

- `npm ci`, `npm run lint:check`, `npm run ts:check`, `npm run style:check`, `npm run build -- --throw-warnings` (robots `Disallow`), `npm run build -- --throw-warnings --unlock-robots` (robots `Allow`), `npm run size:check` (147.00 KB / 155 KB), `npm run smoke`.
- Local Lighthouse (`@lhci/cli` 0.15.1, three runs per URL) on the unlocked production build: see the numbers in the review comment below.

Local Lighthouse on the unlocked production build (three runs per URL, medians):

| URL | Performance | Accessibility | Best practices | SEO | CLS |
| --- | ---: | ---: | ---: | ---: | ---: |
| `/` | 99 | 100 | 100 | 100 | 0.000 |
| `/details` | 98 | 100 | 100 | 100 | 0.017 |

Before (run 33987129813): `/` 96 / 92 / 100 / 66, CLS 0.107; `/details` 99 / 89 / 100 / 63.
