### PR TITLE
chore: use vite-ssr-boost 8.2.0 and react-head-manager 2.2.0 and lower the size budget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@fastify/static": "^10.1.3",
-        "@lomray/react-head-manager": "^2.1.2",
-        "@lomray/vite-ssr-boost": "^8.1.0",
+        "@lomray/react-head-manager": "^2.2.0",
+        "@lomray/vite-ssr-boost": "^8.2.0",
         "fastify": "^5.12.3",
         "isbot": "^5.2.2",
         "react": "^19.2.8",
@@ -1438,9 +1438,9 @@
       }
     },
     "node_modules/@lomray/react-head-manager": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@lomray/react-head-manager/-/react-head-manager-2.1.2.tgz",
-      "integrity": "sha512-iLvcekfL9zcZSBiwvx5CDm9QDYXicxpiul0SIHUZZKtuGdLj6xqmq9MjZ9GlnVs2wHIbHHdgxmaYg7tiTbtetg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@lomray/react-head-manager/-/react-head-manager-2.2.0.tgz",
+      "integrity": "sha512-HKfi57Nn0gHMoYDKaqe8r/hca6S0ISdRI+gUeOlSZVUnqDpAp6KMswhQd61fqhwHKFd2UZATrdQX/8U6by9NOQ==",
       "license": "MIT",
       "dependencies": {
         "html-react-parser": "^5.1.15"
@@ -1471,9 +1471,9 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.1.0.tgz",
-      "integrity": "sha512-30h9QHgxBJGkUTYR51PV5N0PHYCO8rTT2mBUc4tZHwvKnFgsTkoQD3FSMVDa627dChQsIlxJPqVsCZCU8R68+g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.2.0.tgz",
+      "integrity": "sha512-gBk3J5ZQjjBjjYcwRaV238V+VfXwvBij3owUdlO+YX5Vxwf1VlJ74jcuFleQXp578LTbf7XAhkKekA9rqRLiIA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@fastify/static": "^10.1.3",
-    "@lomray/react-head-manager": "^2.1.2",
-    "@lomray/vite-ssr-boost": "^8.1.0",
+    "@lomray/react-head-manager": "^2.2.0",
+    "@lomray/vite-ssr-boost": "^8.2.0",
     "fastify": "^5.12.3",
     "isbot": "^5.2.2",
     "react": "^19.2.8",

--- a/scripts/size-budget.mjs
+++ b/scripts/size-budget.mjs
@@ -2,7 +2,7 @@ import { appendFile, readFile, readdir } from 'node:fs/promises';
 import { gzipSync } from 'node:zlib';
 
 // After an intentional size change, rebuild and set ceil(total gzip bytes * 1.05 / 1024).
-const SIZE_BUDGET_GZIP_KB = 109;
+const SIZE_BUDGET_GZIP_KB = 100;
 
 const assets = new URL('../build/client/assets/', import.meta.url);
 const files = (await readdir(assets)).filter((file) => file.endsWith('.js')).sort();


### PR DESCRIPTION
## Goal

Use `@lomray/vite-ssr-boost` 8.2.0 (development diagnostics) and `@lomray/react-head-manager` 2.2.0 (browser build without an HTML parser, root attributes preserved), and lower the client size budget to the new measurement so the gain cannot silently regress.

## Changes

- `@lomray/vite-ssr-boost` `^8.2.0` (lock 8.2.0) and `@lomray/react-head-manager` `^2.2.0` (lock 2.2.0); no other dependency changes.
- `scripts/size-budget.mjs`: budget lowered to the measured gzip total plus 5 percent, rounded up.

## Verification

`npm ci`, `npm run lint:check`, `npm run ts:check`, `npm run style:check`, `npm run build -- --throw-warnings`, `npm run size:check`, `npm run smoke`, `npm audit`: all green. On `prod` a fetch of `/` from the production server contains exactly one `<head`.
