### PR TITLE
fix: read transferred state inside the browser entry init callback

### DIFF
--- a/scripts/hydration-race-proxy.mjs
+++ b/scripts/hydration-race-proxy.mjs
@@ -1,0 +1,44 @@
+// Run against npm run start:ssr. HTML streams immediately; cache headers are preserved.
+// UPSTREAM=http://127.0.0.1:3000 env -u NO_COLOR node scripts/hydration-race-proxy.mjs
+import http from 'node:http';
+
+const upstream = new URL(process.env.UPSTREAM || 'http://127.0.0.1:3000');
+const moduleDelay = Number(process.env.MODULE_DELAY_MS || 300);
+const server = http.createServer((request, response) => {
+  const target = new URL(request.url, upstream);
+  const upstreamRequest = http.request(
+    target,
+    { method: request.method, headers: { ...request.headers, host: upstream.host } },
+    (upstreamResponse) => {
+      const forward = () => {
+        if (response.destroyed) return;
+        response.writeHead(upstreamResponse.statusCode, upstreamResponse.headers);
+        upstreamResponse.pipe(response);
+      };
+
+      upstreamResponse.on('error', () => response.destroy());
+      if (/\.m?js$/.test(target.pathname)) setTimeout(forward, moduleDelay);
+      else forward();
+    },
+  );
+
+  upstreamRequest.on('error', () => {
+    if (!response.headersSent) response.writeHead(502);
+    response.end('Production server unavailable');
+  });
+  response.on('close', () => upstreamRequest.destroy());
+  request.pipe(upstreamRequest);
+});
+
+server.listen(Number(process.env.PORT || 4174), '127.0.0.1', () => {
+  console.info(
+    `Hydration proxy: http://127.0.0.1:${server.address().port}; JS delay ${moduleDelay} ms`,
+  );
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, () => {
+    server.close();
+    server.closeAllConnections();
+  });
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,20 +8,20 @@ import StateKey from '@constants/state-key';
 import routes from '@routes/index';
 import App from './app';
 
-const initState = getServerState(StateKey.storeManager, IS_PROD);
-const metaState = getServerState(StateKey.metaManager, IS_PROD);
-
-const metaManager = new MetaManager(metaState);
-const storeManager = new Manager({
-  initState,
-  storage: new MobxLocalStorage(),
-});
-
 /**
  * Configure client
  */
 void entryClient(App, routes, {
-  init: async () => {
+  init: async ({ isSSRMode }) => {
+    // The entry waits for the streamed footer before reading transferred state.
+    const initState = isSSRMode ? getServerState(StateKey.storeManager, IS_PROD) : undefined;
+    const metaState = isSSRMode ? getServerState(StateKey.metaManager, IS_PROD) : undefined;
+    const metaManager = new MetaManager(metaState);
+    const storeManager = new Manager({
+      initState,
+      storage: new MobxLocalStorage(),
+    });
+
     await storeManager.init();
 
     return {


### PR DESCRIPTION
## Goal

Close the last place where the template reads transferred state before the browser entry has waited for it.

## Changes

- `src/client.ts`: `getServerState(...)` reads and the creation of `MetaManager`/`Manager` move into the `init` callback of the browser entry, after its wait for `window.__staticRouterHydrationData` (see the library page "Hydration order and streaming"); in the SPA build (`isSSRMode` false) nothing is read.
- `scripts/hydration-race-proxy.mjs`: the proxy from the docs recipe (delays JavaScript responses by 300 ms while streaming HTML) to reproduce the timing locally.

## Verification

`npm run lint:check`, `npm run ts:check`, `npm run style:check`, `npm run build -- --throw-warnings`, `npm run size:check` (138.56 KB / 146 KB), `npm run smoke`, SPA build + `start:spa` (200 without hydration data). Ordering proof in jsdom: before the change both state reads happened before the footer assignment; after it both assignments precede the reads and hydration completes without errors (headless Chrome could not start in the sandbox).
