### PR TITLE
feat: stream loader data with Await on the deferred page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ npm run develop
 - `constants/index` - configure application constants
 - `common/services/route-manager` - configure site routes
 
+## Demo routes
+
+- `/details` shows streamed component data with MobX and consistent-suspense.
+- `/nested-suspense` shows nested boundaries for streamed MobX data.
+- `/deferred` (Deferred data) streams a static user list after 1.5 seconds from a loader promise, read with React Router `<Await>` and React 19 `use()`, with a counter in the shell.
+
 ## Bundle analyze
 ```bash
 vite-bundle-visualizer
@@ -70,6 +76,9 @@ To run the prod checks locally, build the app, run `npm run start:ssr -- --port 
 Lighthouse reports are uploaded to temporary public storage.
 
 ## Some cases to pay attention to.
+
+With vite-ssr-boost `^8.3.0-beta.1` in Data mode, return slow values as promises inside the loader result, such as `{ title: 'Deferred data', users: fetchUsers() }`, and read them with `<Await>` or React 19 `use()` inside React `<Suspense>` boundaries. The `/deferred` page demonstrates both consumers sharing one promise. This template enables `hydration: 'early'`: request-scoped managers are initialized before rendering, `getState` snapshots are available at `onShellReady`, and later MobX stores still travel through `ManagerStream` before their boundaries resolve. Shell controls keep their state local so updates do not rerender pending boundaries. See the [streaming guide](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/docs/guide/data-streaming.md).
+
  - Right solution for wrap `<Outlet />` into `<Suspense />`. If you would like to wrap your lazy routes only once:
 ```typescript jsx
 import { Outlet, useLocation } from 'react-router-dom';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lomray/react-head-manager": "^2.2.0",
         "@lomray/react-mobx-manager": "^4.5.1",
         "@lomray/react-route-manager": "^2.0.0",
-        "@lomray/vite-ssr-boost": "^8.2.0",
+        "@lomray/vite-ssr-boost": "^8.3.0",
         "axios": "^1.20.0",
         "classnames": "^2.5.1",
         "cookie-parser": "^1.4.7",
@@ -1282,15 +1282,19 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.2.0.tgz",
-      "integrity": "sha512-gBk3J5ZQjjBjjYcwRaV238V+VfXwvBij3owUdlO+YX5Vxwf1VlJ74jcuFleQXp578LTbf7XAhkKekA9rqRLiIA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.3.0.tgz",
+      "integrity": "sha512-7aOpJ7nuNZEDGVyfBDrsuRzBgOsI94coI7pzjs0PWcZIR8HRQPZTKZgzyCCZA6NvbV3Jt9ZIFdMm7NgClW2EQg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
+        "devalue": "^5.9.2",
+        "diff": "^9.0.0",
         "hoist-non-react-statics": "^3.3.2",
-        "json5": "^2.2.3"
+        "json5": "^2.2.3",
+        "parse5": "^8.0.1",
+        "semver": "^7.8.5"
       },
       "bin": {
         "ssr-boost": "cli.js"
@@ -1325,6 +1329,18 @@
         "@types/serve-static": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@lomray/vite-ssr-boost/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4902,6 +4918,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -5061,7 +5092,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -11911,7 +11941,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@lomray/react-head-manager": "^2.2.0",
     "@lomray/react-mobx-manager": "^4.5.1",
     "@lomray/react-route-manager": "^2.0.0",
-    "@lomray/vite-ssr-boost": "^8.2.0",
+    "@lomray/vite-ssr-boost": "^8.3.0",
     "axios": "^1.20.0",
     "classnames": "^2.5.1",
     "cookie-parser": "^1.4.7",

--- a/scripts/size-budget.mjs
+++ b/scripts/size-budget.mjs
@@ -2,7 +2,7 @@ import { appendFile, readFile, readdir } from 'node:fs/promises';
 import { gzipSync } from 'node:zlib';
 
 // After an intentional size change, rebuild and set ceil(total gzip bytes * 1.05 / 1024).
-const SIZE_BUDGET_GZIP_KB = 146;
+const SIZE_BUDGET_GZIP_KB = 150;
 
 const assets = new URL('../build/client/assets/', import.meta.url);
 const files = (await readdir(assets)).filter((file) => file.endsWith('.js')).sort();

--- a/scripts/smoke.config.json
+++ b/scripts/smoke.config.json
@@ -1,6 +1,12 @@
 {
   "routes": [
     { "path": "/", "status": 200, "contains": ["window.__staticRouterHydrationData"] },
+    {
+      "path": "/deferred",
+      "status": 200,
+      "contains": ["Deferred data"],
+      "containsAny": ["Loading users with Await", "Ada Lovelace"]
+    },
     { "path": "/not-lazy", "status": 200, "contains": ["Styled text"] },
     { "path": "/redirect-demo", "status": 301 },
     { "path": "/missing", "status": 404 },
@@ -10,5 +16,11 @@
     { "path": "/only-client-page", "status": 200 }
   ],
   "streamPath": "/details",
-  "crawlerCookie": "isCrawler=1"
+  "crawlerCookie": "isCrawler=1",
+  "crawlerRoutes": [
+    {
+      "path": "/deferred",
+      "contains": ["<li>Ada Lovelace</li>", "<li>Grace Hopper</li>", "<li>Margaret Hamilton</li>"]
+    }
+  ]
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -173,7 +173,7 @@ try {
   const config = JSON.parse(
     await readFile(new URL('./smoke.config.json', import.meta.url), 'utf8'),
   );
-  const { routes, streamPath, crawlerCookie } = config;
+  const { routes, streamPath, crawlerCookie, crawlerRoutes } = config;
 
   assert.ok(Array.isArray(routes) && routes.length > 0, 'Configure at least one smoke route.');
   assert.ok(typeof streamPath === 'string' && streamPath.startsWith('/'), 'Configure streamPath.');
@@ -184,7 +184,7 @@ try {
 
   await build();
   await withServer('SSR', [], async (origin) => {
-    for (const { path, status, contains = [], headers = {} } of routes) {
+    for (const { path, status, contains = [], containsAny = [], headers = {} } of routes) {
       const response = await inspect(origin, path, { headers });
 
       assert.equal(response.status, status, `SSR GET ${path}: expected status ${status}.`);
@@ -195,7 +195,14 @@ try {
         );
       }
 
-      console.info(`[smoke] SSR GET ${path}: ${status}; ${contains.length} content checks passed.`);
+      if (containsAny.length > 0) {
+        assert.ok(
+          containsAny.some((marker) => response.html.includes(marker)),
+          `SSR GET ${path}: expected one of ${JSON.stringify(containsAny)}.`,
+        );
+      }
+
+      console.info(`[smoke] SSR GET ${path}: ${status}; content checks passed.`);
     }
 
     const first = routes[0];
@@ -222,11 +229,25 @@ try {
       `SSR crawler ${streamPath}: pending Suspense boundary.`,
     );
     console.info(`[smoke] SSR crawler ${streamPath}: 200; no pending Suspense boundaries.`);
+
+    for (const { path, contains } of crawlerRoutes) {
+      const response = await inspect(origin, path, { headers: { 'User-Agent': 'Googlebot' } });
+
+      assert.equal(response.status, 200, `SSR Googlebot ${path}: expected status 200.`);
+      for (const marker of contains) {
+        assert.ok(response.html.includes(marker), `SSR Googlebot ${path}: missing ${marker}.`);
+      }
+      assert.ok(
+        !response.html.includes('<!--$?-->'),
+        `SSR Googlebot ${path}: pending Suspense boundary.`,
+      );
+      console.info(`[smoke] SSR Googlebot ${path}: 200; resolved users; no pending boundaries.`);
+    }
   });
 
   await build(['--focus-only', 'client']);
   await withServer('SPA', ['--focus-only', 'client'], async (origin) => {
-    for (const path of ['/', streamPath]) {
+    for (const path of ['/', streamPath, '/deferred']) {
       const response = await inspect(origin, path);
 
       assert.equal(response.status, 200, `SPA GET ${path}: expected status 200.`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import App from './app';
  */
 void entryClient(App, routes, {
   init: async ({ isSSRMode }) => {
-    // The entry waits for the streamed footer before reading transferred state.
+    // The entry waits for shell state and React's shell marker before hydration.
     const initState = isSSRMode ? getServerState(StateKey.storeManager, IS_PROD) : undefined;
     const metaState = isSSRMode ? getServerState(StateKey.metaManager, IS_PROD) : undefined;
     const metaManager = new MetaManager(metaState);

--- a/src/common/services/route-manager.ts
+++ b/src/common/services/route-manager.ts
@@ -17,6 +17,9 @@ const manager = new Manager({
         },
       },
     },
+    deferred: {
+      url: '/deferred',
+    },
     errorBoundary: {
       url: '/error-boundary',
     },

--- a/src/pages/deferred/index.tsx
+++ b/src/pages/deferred/index.tsx
@@ -1,0 +1,77 @@
+import { Meta } from '@lomray/react-head-manager';
+import type { FC } from 'react';
+import { Suspense, use, useState } from 'react';
+import { Await, Link, useLoaderData } from 'react-router';
+import RouteManager from '@services/route-manager';
+
+const fetchUsers = async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 1500);
+  });
+
+  return [
+    { id: '1', name: 'Ada Lovelace' },
+    { id: '2', name: 'Grace Hopper' },
+    { id: '3', name: 'Margaret Hamilton' },
+  ];
+};
+
+export const loader = () => ({ title: 'Deferred data', users: fetchUsers() });
+
+type Users = Awaited<ReturnType<typeof fetchUsers>>;
+
+const UserList: FC<{ users: Users }> = ({ users }) => (
+  <ul>
+    {users.map((user) => (
+      <li key={user.id}>{user.name}</li>
+    ))}
+  </ul>
+);
+
+const UsersWithUse: FC<{ promise: Promise<Users> }> = ({ promise }) => (
+  <UserList users={use(promise)} />
+);
+
+// Keep shell updates local while the data boundaries are still hydrating.
+const Counter: FC = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <button type="button" onClick={() => setCount((value) => value + 1)}>
+      Count: {count}
+    </button>
+  );
+};
+
+const Deferred: FC = () => {
+  const data = useLoaderData<ReturnType<typeof loader>>();
+
+  return (
+    <>
+      <Meta>
+        <title>{data.title}</title>
+        <meta name="description" content="Stream users from a React Router loader." />
+      </Meta>
+      <h1>{data.title}</h1>
+      <p>The title arrives first. Users follow after 1.5 seconds.</p>
+      <Counter />
+      <section aria-labelledby="await-users">
+        <h2 id="await-users">Users with Await</h2>
+        <Suspense fallback={<p>Loading users with Await…</p>}>
+          <Await resolve={data.users} errorElement={<p role="alert">Could not load users.</p>}>
+            {(users: Users) => <UserList users={users} />}
+          </Await>
+        </Suspense>
+      </section>
+      <section aria-labelledby="use-users">
+        <h2 id="use-users">Users with React use()</h2>
+        <Suspense fallback={<p>Loading users with use()…</p>}>
+          <UsersWithUse promise={data.users} />
+        </Suspense>
+      </section>
+      <Link to={RouteManager.makeURL('home')}>Go back</Link>
+    </>
+  );
+};
+
+export { Deferred as Component };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -87,6 +87,9 @@ const Home: FCRoute = () => {
           You are watching site like: <strong>{isCrawler ? 'Search bot' : 'Human'}</strong>
         </button>
         <p>
+          <Link to={RouteManager.makeURL('deferred')}>Deferred data</Link>
+        </p>
+        <p>
           <Link to={RouteManager.makeURL('details')}>How to works Suspense?</Link>
         </p>
         <p>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -19,6 +19,10 @@ const routes: TRouteObject[] = [
         lazy: () => import('@pages/home'),
       },
       {
+        path: RouteManager.path('deferred'),
+        lazy: () => import('@pages/deferred'),
+      },
+      {
         path: RouteManager.path('details'),
         children: DetailsRoutes,
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,8 @@ const isBot = createIsbotFromList(list.filter((record) => !patternsToRemove.has(
 export default entryServer(App, routes, {
   abortDelay: 20000,
   init: () => ({
+    // getState is ready at onShellReady; later MobX stores use ManagerStream below.
+    hydration: 'early',
     /**
      * Once after create server
      */
@@ -108,7 +110,7 @@ export default entryServer(App, routes, {
       return isEnd ? streamSuspense.end() : streamSuspense.analyze(html);
     },
     /**
-     * Return server state to client (once when app she'll ready) for:
+     * Return server state to client once at shell readiness for:
      * 1. Mobx manager (stores)
      * 2. Meta manager
      */


### PR DESCRIPTION
## Goal

Show the new streamed loader data of `@lomray/vite-ssr-boost` 8.3.0 in the template: a loader returns a promise and `<Await>` (and React 19 `use()` on `prod`) hydrate it in Data mode.

## Changes

- `@lomray/vite-ssr-boost` `^8.3.0` (lock 8.3.0; the only other lock addition is its `devalue` dependency).
- New route `/deferred`: the loader returns `{ title, users: fetchUsers() }` where the users resolve after 1.5 s; the page renders the title and a counter immediately and lists the users inside `<Suspense>` + `<Await errorElement>` (plus a second list through `use()` on `prod`). Linked from the home page.
- `prod` only: `hydration: 'early'` in the server entry; `getState` is available at `onShellReady`, and the MobX demos (`/details`, `/nested-suspense`) keep the same `window.mbxM.push` sequence before each `$RC`.
- Smoke: `/deferred` route check and a Googlebot check requiring the resolved users and no pending boundary; README paragraph on returning promises from loaders.
- Size budget raised to the new measurement plus 5 percent.

## Verification

`npm ci`, `npm run lint:check`, `npm run ts:check`, `npm run style:check`, `npm run build -- --throw-warnings`, `npm run size:check`, `npm run smoke`, `npm audit` green. Streamed capture: title, counter and fallback at ~15 ms, resolved users ~1.5 s later; Googlebot gets the full list with zero `<!--$?-->`. Browser: the counter responds while the users are still pending, no console errors, `/details` still hydrates its streamed stores.
