### PR TITLE
feat: stream loader data with Await on the deferred page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Minimal SSR example
 
-This is the `example/minimal` branch of vite-template, using React 19, React Router 8, Vite 8, and vite-ssr-boost 8.0.0.
+This is the `example/minimal` branch of vite-template, using React 19, React Router 8, Vite 8, and vite-ssr-boost 8.3.0-beta.1.
 The app uses React Router [Data mode](https://reactrouter.com/start/modes#data).
 
 - Server-rendered pages with a title and description from a request-scoped meta manager.
 - Resolved loader data on `/users`, a user page on `/users/:id`, and a loader error boundary for unknown IDs.
+- `/deferred` (Deferred data) streams a static user list after 1.5 seconds from a loader promise through React Router `<Await>`, with a title and counter in the shell.
 - A lazy `/about` route with its own CSS module injected into the server response.
 - A server-aware 301 redirect, a browser-only route with a fallback, and a 404 page.
 - Development reloads and SSR or SPA builds from the same application.
@@ -14,7 +15,7 @@ The app uses React Router [Data mode](https://reactrouter.com/start/modes#data).
 Use Node 22.23.2 (`.nvmrc`) and npm.
 The six direct runtime dependencies and their versions are listed in [package.json](package.json).
 They are `react`, `react-dom`, `react-router`, `@lomray/vite-ssr-boost`, `@lomray/react-head-manager`, and `isbot`.
-Keep vite-ssr-boost on the `^8.0.0` range while using this example.
+Keep vite-ssr-boost on the `^8.3.0-beta.1` range while using this example.
 The head manager also installs `@lomray/consistent-suspense` as a transitive peer dependency; application code does not import it.
 
 This comparison starts with Data-mode route objects, a shared `App` wrapper, and metadata already in the SPA.
@@ -241,7 +242,7 @@ This branch disables Vercel automatic deployments; the `prod` branch keeps the d
 ## Pitfalls
 
 - Browser globals: keep `window` out of module scope in server-imported code; use a lazy `onlyClient` route with a fallback for browser-only pages ([working route](src/routes/index.ts), [page](src/pages/client-only/index.tsx)).
-- Loader promises: await first-paint data before returning it, because nested promises become `{}` when `window.__staticRouterHydrationData` is serialized with `JSON.stringify`, so `<Await>` or `use()` cannot hydrate that data; streamed data needs component-level Suspense, a request-scoped cache, and `getState` ([serializer](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/src/helpers/build-router-state.ts), [resolved loader](src/pages/users/index.tsx), [streamed data example](https://github.com/Lomray-Software/vite-template/tree/prod)).
+- Loader promises: return critical data immediately and leave slow fields as promises, then read them with `<Await>` inside React `<Suspense>` ([deferred page](src/pages/deferred/index.tsx), [streaming guide](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/docs/guide/data-streaming.md)). This example keeps the default footer hydration; the `prod` branch also demonstrates early shell hydration and React 19 `use()`.
 - Dependency CSS: add packages that import CSS to `ssr.noExternal` when they need Vite's server transforms ([Vite SSR externals](https://vite.dev/guide/ssr.html#ssr-externals)).
 - Environment variables: read public values through `import.meta.env`, keep secrets out of `VITE_*`, and restart development after changing env files ([Vite env variables](https://vite.dev/guide/env-and-mode.html)).
 - Hydration mismatches: compare the initial browser render with the server HTML and check data, dates, randomness, and browser-dependent branches ([React hydration troubleshooting](https://react.dev/reference/react-dom/client/hydrateRoot#troubleshooting)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@lomray/react-head-manager": "^2.2.0",
-        "@lomray/vite-ssr-boost": "^8.2.0",
+        "@lomray/vite-ssr-boost": "^8.3.0",
         "isbot": "^5.2.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -1244,15 +1244,19 @@
       }
     },
     "node_modules/@lomray/vite-ssr-boost": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.2.0.tgz",
-      "integrity": "sha512-gBk3J5ZQjjBjjYcwRaV238V+VfXwvBij3owUdlO+YX5Vxwf1VlJ74jcuFleQXp578LTbf7XAhkKekA9rqRLiIA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lomray/vite-ssr-boost/-/vite-ssr-boost-8.3.0.tgz",
+      "integrity": "sha512-7aOpJ7nuNZEDGVyfBDrsuRzBgOsI94coI7pzjs0PWcZIR8HRQPZTKZgzyCCZA6NvbV3Jt9ZIFdMm7NgClW2EQg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
+        "devalue": "^5.9.2",
+        "diff": "^9.0.0",
         "hoist-non-react-statics": "^3.3.2",
-        "json5": "^2.2.3"
+        "json5": "^2.2.3",
+        "parse5": "^8.0.1",
+        "semver": "^7.8.5"
       },
       "bin": {
         "ssr-boost": "cli.js"
@@ -1287,6 +1291,18 @@
         "@types/serve-static": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@lomray/vite-ssr-boost/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4354,6 +4370,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4514,7 +4545,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -11024,7 +11054,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@lomray/react-head-manager": "^2.2.0",
-    "@lomray/vite-ssr-boost": "^8.2.0",
+    "@lomray/vite-ssr-boost": "^8.3.0",
     "isbot": "^5.2.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/scripts/size-budget.mjs
+++ b/scripts/size-budget.mjs
@@ -2,7 +2,7 @@ import { appendFile, readFile, readdir } from 'node:fs/promises';
 import { gzipSync } from 'node:zlib';
 
 // After an intentional size change, rebuild and set ceil(total gzip bytes * 1.05 / 1024).
-const SIZE_BUDGET_GZIP_KB = 100;
+const SIZE_BUDGET_GZIP_KB = 103;
 
 const assets = new URL('../build/client/assets/', import.meta.url);
 const files = (await readdir(assets)).filter((file) => file.endsWith('.js')).sort();

--- a/scripts/smoke.config.json
+++ b/scripts/smoke.config.json
@@ -6,6 +6,12 @@
       "contains": ["Minimal SSR example", "window.__staticRouterHydrationData"]
     },
     {
+      "path": "/deferred",
+      "status": 200,
+      "contains": ["Deferred data"],
+      "containsAny": ["Loading users with Await", "Ada Lovelace"]
+    },
+    {
       "path": "/users",
       "status": 200,
       "contains": ["Ada Lovelace"]
@@ -33,5 +39,11 @@
     }
   ],
   "streamPath": "/about",
-  "crawlerCookie": "isCrawler=1"
+  "crawlerCookie": "isCrawler=1",
+  "crawlerRoutes": [
+    {
+      "path": "/deferred",
+      "contains": ["<li>Ada Lovelace</li>", "<li>Grace Hopper</li>", "<li>Margaret Hamilton</li>"]
+    }
+  ]
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -173,7 +173,7 @@ try {
   const config = JSON.parse(
     await readFile(new URL('./smoke.config.json', import.meta.url), 'utf8'),
   );
-  const { routes, streamPath, crawlerCookie } = config;
+  const { routes, streamPath, crawlerCookie, crawlerRoutes } = config;
 
   assert.ok(Array.isArray(routes) && routes.length > 0, 'Configure at least one smoke route.');
   assert.ok(typeof streamPath === 'string' && streamPath.startsWith('/'), 'Configure streamPath.');
@@ -184,7 +184,7 @@ try {
 
   await build();
   await withServer('SSR', [], async (origin) => {
-    for (const { path, status, contains = [], headers = {} } of routes) {
+    for (const { path, status, contains = [], containsAny = [], headers = {} } of routes) {
       const response = await inspect(origin, path, { headers });
 
       assert.equal(response.status, status, `SSR GET ${path}: expected status ${status}.`);
@@ -195,7 +195,14 @@ try {
         );
       }
 
-      console.info(`[smoke] SSR GET ${path}: ${status}; ${contains.length} content checks passed.`);
+      if (containsAny.length > 0) {
+        assert.ok(
+          containsAny.some((marker) => response.html.includes(marker)),
+          `SSR GET ${path}: expected one of ${JSON.stringify(containsAny)}.`,
+        );
+      }
+
+      console.info(`[smoke] SSR GET ${path}: ${status}; content checks passed.`);
     }
 
     const first = routes[0];
@@ -222,11 +229,25 @@ try {
       `SSR crawler ${streamPath}: pending Suspense boundary.`,
     );
     console.info(`[smoke] SSR crawler ${streamPath}: 200; no pending Suspense boundaries.`);
+
+    for (const { path, contains } of crawlerRoutes) {
+      const response = await inspect(origin, path, { headers: { 'User-Agent': 'Googlebot' } });
+
+      assert.equal(response.status, 200, `SSR Googlebot ${path}: expected status 200.`);
+      for (const marker of contains) {
+        assert.ok(response.html.includes(marker), `SSR Googlebot ${path}: missing ${marker}.`);
+      }
+      assert.ok(
+        !response.html.includes('<!--$?-->'),
+        `SSR Googlebot ${path}: pending Suspense boundary.`,
+      );
+      console.info(`[smoke] SSR Googlebot ${path}: 200; resolved users; no pending boundaries.`);
+    }
   });
 
   await build(['--focus-only', 'client']);
   await withServer('SPA', ['--focus-only', 'client'], async (origin) => {
-    for (const path of ['/', streamPath]) {
+    for (const path of ['/', streamPath, '/deferred']) {
       const response = await inspect(origin, path);
 
       assert.equal(response.status, 200, `SPA GET ${path}: expected status 200.`);

--- a/src/common/components/layouts/app/index.tsx
+++ b/src/common/components/layouts/app/index.tsx
@@ -10,6 +10,7 @@ const AppLayout: FC = () => {
         <nav aria-label="Main navigation">
           <Link to="/">Home</Link>
           <Link to="/users">Users</Link>
+          <Link to="/deferred">Deferred data</Link>
           <Link to="/about">About</Link>
           <Link to="/client-only">Client only</Link>
         </nav>

--- a/src/pages/deferred/index.tsx
+++ b/src/pages/deferred/index.tsx
@@ -1,0 +1,57 @@
+import { Meta } from '@lomray/react-head-manager';
+import type { FC } from 'react';
+import { Suspense, useState } from 'react';
+import { Await, useLoaderData } from 'react-router';
+import users from '@data/users';
+
+const fetchUsers = async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 1500);
+  });
+
+  return users;
+};
+
+export const loader = () => ({ title: 'Deferred data', users: fetchUsers() });
+
+const Counter: FC = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <button type="button" onClick={() => setCount((value) => value + 1)}>
+      Count: {count}
+    </button>
+  );
+};
+
+const Deferred: FC = () => {
+  const data = useLoaderData<ReturnType<typeof loader>>();
+
+  return (
+    <>
+      <Meta>
+        <title>{data.title}</title>
+        <meta name="description" content="Stream users from a React Router loader." />
+      </Meta>
+      <h1>{data.title}</h1>
+      <p>The title arrives first. Users follow after 1.5 seconds.</p>
+      <Counter />
+      <section aria-labelledby="await-users">
+        <h2 id="await-users">Users with Await</h2>
+        <Suspense fallback={<p>Loading users with Await…</p>}>
+          <Await resolve={data.users} errorElement={<p role="alert">Could not load users.</p>}>
+            {(resolvedUsers: typeof users) => (
+              <ul>
+                {resolvedUsers.map((user) => (
+                  <li key={user.id}>{user.name}</li>
+                ))}
+              </ul>
+            )}
+          </Await>
+        </Suspense>
+      </section>
+    </>
+  );
+};
+
+export { Deferred as Component };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -15,6 +15,9 @@ const Home: FC = () => (
     <p>React routes, server-rendered HTML, and the same app in your browser.</p>
     <ul>
       <li>
+        <Link to="/deferred">Deferred data</Link>
+      </li>
+      <li>
         <Link to="/users">Load users before rendering</Link>
       </li>
       <li>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,6 +12,7 @@ const routes = [
     children: [
       { path: '/', Component: Home },
       { path: '/users', Component: Users, loader: usersLoader },
+      { path: '/deferred', lazy: () => import('@pages/deferred') },
       { path: '/users/:id', Component: User, loader: userLoader, ErrorBoundary },
       { path: '/about', lazy: () => import('@pages/about') },
       { path: '/redirect', Component: Redirect },


### PR DESCRIPTION
## Goal

Show the new streamed loader data of `@lomray/vite-ssr-boost` 8.3.0 in the template: a loader returns a promise and `<Await>` (and React 19 `use()` on `prod`) hydrate it in Data mode.

## Changes

- `@lomray/vite-ssr-boost` `^8.3.0` (lock 8.3.0; the only other lock addition is its `devalue` dependency).
- New route `/deferred`: the loader returns `{ title, users: fetchUsers() }` where the users resolve after 1.5 s; the page renders the title and a counter immediately and lists the users inside `<Suspense>` + `<Await errorElement>` (plus a second list through `use()` on `prod`). Linked from the home page.
- `prod` only: `hydration: 'early'` in the server entry; `getState` is available at `onShellReady`, and the MobX demos (`/details`, `/nested-suspense`) keep the same `window.mbxM.push` sequence before each `$RC`.
- Smoke: `/deferred` route check and a Googlebot check requiring the resolved users and no pending boundary; README paragraph on returning promises from loaders.
- Size budget raised to the new measurement plus 5 percent.

## Verification

`npm ci`, `npm run lint:check`, `npm run ts:check`, `npm run style:check`, `npm run build -- --throw-warnings`, `npm run size:check`, `npm run smoke`, `npm audit` green. Streamed capture: title, counter and fallback at ~15 ms, resolved users ~1.5 s later; Googlebot gets the full list with zero `<!--$?-->`. Browser: the counter responds while the users are still pending, no console errors, `/details` still hydrates its streamed stores.
