### PR TITLE
docs: register the tanstack query example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,30 @@ updates:
 
   - package-ecosystem: npm
     directory: /
+    target-branch: example/tanstack-query
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies]
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      lomray:
+        patterns: ['@lomray/*']
+        update-types: [major, minor, patch]
+      non-major:
+        patterns: ['*']
+        exclude-patterns: ['@lomray/*']
+        update-types: [minor, patch]
+    ignore:
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: npm
+    directory: /
     target-branch: example/custom-server
     schedule:
       interval: weekly

--- a/.github/workflows/example-check.yml
+++ b/.github/workflows/example-check.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ github.event_name == 'schedule' && fromJSON('["prod", "example/minimal", "example/custom-server", "example/localization"]') || fromJSON(format('["{0}"]', github.ref_name)) }}
+        branch: ${{ github.event_name == 'schedule' && fromJSON('["prod", "example/minimal", "example/tanstack-query", "example/custom-server", "example/localization"]') || fromJSON(format('["{0}"]', github.ref_name)) }}
     concurrency:
       group: ${{ matrix.branch }}-check-example
       cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 | --- | --- | --- | --- |
 | `prod` | Streaming SSR, MobX, consistent Suspense, meta tags and route management | Use the full reference app | [Browse](https://github.com/Lomray-Software/vite-template/tree/prod) |
 | `example/minimal` | Six runtime dependencies, loaders, a lazy route with CSS, redirect, client-only route and 404, plus the SPA-to-SSR file diff | Start with a small SSR app | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/minimal) |
+| `example/tanstack-query` | TanStack Query kept from an existing SPA: per-request `QueryClient`, `prefetchQuery` + `dehydrate` in loaders, a pending detail query streamed through `useSuspenseQuery`, `HydrationBoundary` on the client, with cache and browser tests | Keep TanStack Query and add SSR | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/tanstack-query) |
 | `example/custom-server` | Development through the managed CLI, production through an application-owned Fastify server with static assets, compression and Early Hints; dual export of the managed entry and a Fetch handler | Own the production server | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/custom-server) |
 | `example/localization` | i18next with the language chosen on the server from the cookie or Accept-Language, transferred to the client before hydration, and a cookie-based switcher | Add localization | [Browse](https://github.com/Lomray-Software/vite-template/tree/example/localization) |
 


### PR DESCRIPTION
Registers the new `example/tanstack-query` branch (TanStack Query kept from an existing SPA, with prefetch/dehydrate loaders, a streamed pending detail query, cache and browser tests) in the README examples table, the Dependabot target branches and the weekly example check matrix. The branch itself is at cf4b087.
