### PR TITLE
chore: accept feat, fix, refactor and chore branch prefixes

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -5,7 +5,7 @@ export LC_ALL=C
 
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 
-valid_branch_regex="^(feature|bugfix|improvement|hotfix|example)/[a-z0-9-]+$"
+valid_branch_regex="^(feat|fix|refactor|chore|feature|bugfix|improvement|hotfix|example)/[a-z0-9-]+$"
 
 message="There is something wrong with your branch name. Branch names in this project must adhere to this contract: $valid_branch_regex. Your commit will be rejected. You should rename your branch to a valid name and try again."
 


### PR DESCRIPTION
## Summary
- The commit-msg hook now also accepts `feat/`, `fix/`, `refactor/` and `chore/` branch names next to the existing prefixes.

## Test plan
- [x] Hook regex checked against `feat/x`, `chore/x`, `example/x` locally
- [x] CI check on this PR