### PR TITLE
fix: load the home logo from the configured base url

### DIFF
--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -52,7 +52,13 @@ const Home: FCRoute = () => {
       </div>
       <div className={styles.logos}>
         <a href="https://vitejs.dev/" target="_blank" rel="nofollow">
-          <img src="/vite.svg" width={256} height={257} className={styles.logo} alt="Vite logo" />
+          <img
+            src={`${import.meta.env.BASE_URL}vite.svg`}
+            width={256}
+            height={257}
+            className={styles.logo}
+            alt="Vite logo"
+          />
         </a>
         <a href="https://react.dev" target="_blank" rel="nofollow">
           <img


### PR DESCRIPTION
## Summary
- The home page logo is requested through `import.meta.env.BASE_URL`, so a deployment under a sub-path (`base: '/app/'`) no longer requests `/vite.svg` from the site root and gets a 404. Found by the library's template navigation browser check under a basename.

## Test plan
- [x] Rendered path stays `/vite.svg` with the default base
- [ ] PR check (lint, types, build, smoke)
